### PR TITLE
rt.z - Expose commit info on api/systemInfo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV NODE_VERSION=16.20.0
 RUN apk add curl
 RUN apk add bash
 RUN apk add maven
+RUN apk add git
 RUN apk add --no-cache libstdc++
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
@@ -15,8 +16,8 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-RUN node --version
-RUN npm --version
+# RUN node --version
+# RUN npm --version
 
 COPY . /home/app
 RUN la -al /home/app ; exit 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,9 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN node --version
 RUN npm --version
 
-COPY frontend /home/app/frontend
-COPY src /home/app/src
-COPY lombok.config /home/app
-COPY pom.xml /home/app
+COPY . /home/app
+RUN la -al /home/app ; exit 0
+RUN cd /home/app && git status && git log | head -20; exit 0
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ENV NODE_VERSION=16.20.0
 RUN apk add curl
 RUN apk add bash
 RUN apk add maven
-RUN apk add git
 RUN apk add --no-cache libstdc++
+RUN apk add git
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
@@ -16,11 +16,11 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-RUN node --version
-RUN npm --version
+# This approach (copying entire directory including git info) 
+# relies on the dokku setting:
+#   dokku git:set appname keep-git-dir true
 
 COPY . /home/app
-RUN cd /home/app && git status && git log | head -20; exit 0
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN node --version
 RUN npm --version
 
 COPY . /home/app
-RUN la -al /home/app ; exit 0
 RUN cd /home/app && git status && git log | head -20; exit 0
 
 ENV PRODUCTION=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-# RUN node --version
-# RUN npm --version
+RUN node --version
+RUN npm --version
 
 COPY . /home/app
 RUN la -al /home/app ; exit 0

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,26 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
 
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>8.0.2</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                </configuration>
+            </plugin>
+
             <!-- Test case coverage report -->
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
-
             <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,10 @@
                 <configuration>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.commit.message.short$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+                    </includeOnlyProperties>
                     <commitIdGenerationMode>full</commitIdGenerationMode>
                 </configuration>
             </plugin>
@@ -404,6 +408,14 @@
                         </executions>
                     </plugin>
                 </plugins>
+                <resources>     
+                    <resource>
+                        <directory>src/main/resources</directory>
+                        <includes>                      
+                            <include>**/*.properties</include>                  
+                        </includes>
+                    </resource>            
+                </resources>
             </build>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -407,14 +407,6 @@
                         </executions>
                     </plugin>
                 </plugins>
-                <resources>     
-                    <resource>
-                        <directory>src/main/resources</directory>
-                        <includes>                      
-                            <include>**/*.properties</include>                  
-                        </includes>
-                    </resource>            
-                </resources>
             </build>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -407,6 +407,17 @@
                         </executions>
                     </plugin>
                 </plugins>
+                <resources>     
+                    <resource>
+                        <directory>src/main/resources</directory>
+                        <includes>                      
+                            <include>**/*.properties</include>
+                            <include>db/migration/changes/*.json</include>                  
+                            <include>db/migration/*.json</include>                  
+
+                        </includes>
+                    </resource>            
+                </resources>
             </build>
         </profile>
     </profiles>

--- a/src/main/java/edu/ucsb/cs156/organic/intercepters/RoleUserInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/organic/intercepters/RoleUserInterceptor.java
@@ -1,4 +1,4 @@
-package edu.ucsb.cs156.organic.intercepters;
+package edu.ucsb.cs156.organic.interceptors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/src/main/java/edu/ucsb/cs156/organic/intercepters/RoleUserInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/organic/intercepters/RoleUserInterceptor.java
@@ -1,4 +1,4 @@
-package edu.ucsb.cs156.organic.interceptors;
+package edu.ucsb.cs156.organic.intercepters;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/src/main/java/edu/ucsb/cs156/organic/intercepters/RoleUserInterceptorAppConfig.java
+++ b/src/main/java/edu/ucsb/cs156/organic/intercepters/RoleUserInterceptorAppConfig.java
@@ -1,4 +1,4 @@
-package edu.ucsb.cs156.organic.interceptors;
+package edu.ucsb.cs156.organic.intercepters;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/edu/ucsb/cs156/organic/intercepters/RoleUserInterceptorAppConfig.java
+++ b/src/main/java/edu/ucsb/cs156/organic/intercepters/RoleUserInterceptorAppConfig.java
@@ -1,4 +1,4 @@
-package edu.ucsb.cs156.organic.intercepters;
+package edu.ucsb.cs156.organic.interceptors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/edu/ucsb/cs156/organic/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/organic/models/SystemInfo.java
@@ -14,4 +14,8 @@ public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
   private String sourceRepo;
+  private String commitMessage;
+  private String branch;
+  private String commitId;
+  private String githubUrl; 
 }

--- a/src/main/java/edu/ucsb/cs156/organic/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/organic/models/SystemInfo.java
@@ -15,7 +15,6 @@ public class SystemInfo {
   private Boolean showSwaggerUILink;
   private String sourceRepo;
   private String commitMessage;
-  private String branch;
   private String commitId;
   private String githubUrl; 
 }

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.organic.services;
 
+//import io.github.cdimascio.dotenv.Dotenv;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,9 +17,10 @@ import edu.ucsb.cs156.organic.models.SystemInfo;
 @Slf4j
 @Service("systemInfo")
 @ConfigurationProperties
-@PropertySources(
-  @PropertySource("classpath:git.properties")
-)
+@PropertySources({
+  @PropertySource("classpath:git.properties"),
+  @PropertySource("classpath:application.properties")
+})
 public class SystemInfoServiceImpl extends SystemInfoService {
   
   @Value("${spring.h2.console.enabled:false}")
@@ -26,6 +28,9 @@ public class SystemInfoServiceImpl extends SystemInfoService {
 
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
+
+  @Value("${app.admin.githubLogins}")
+  private String adminLogins;
 
   @Value("${app.sourceRepo}")
   private String sourceRepo;
@@ -37,6 +42,8 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   private String commitId;
 
   public SystemInfo getSystemInfo() {
+    //Dotenv dotenv = Dotenv.load();
+    //if (dotenv.get("REPOSITORY") != null) { sourceRepo = dotenv.get("REPOSITORY"); }
     SystemInfo si = SystemInfo.builder()
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
     .showSwaggerUILink(this.showSwaggerUILink)
@@ -47,6 +54,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     .build();
   log.info("getSystemInfo returns {}",si);
   //System.out.println(sourceRepo);
+  log.info("adminLogins = {}",adminLogins);
   log.info("sourceRepo = {}", sourceRepo);
   return si;
   }

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -4,6 +4,8 @@ package edu.ucsb.cs156.organic.services;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 import org.springframework.stereotype.Service;
 
 import edu.ucsb.cs156.organic.models.SystemInfo;
@@ -14,6 +16,9 @@ import edu.ucsb.cs156.organic.models.SystemInfo;
 @Slf4j
 @Service("systemInfo")
 @ConfigurationProperties
+@PropertySources(
+  @PropertySource("classpath:git.properties")
+)
 public class SystemInfoServiceImpl extends SystemInfoService {
   
   @Value("${spring.h2.console.enabled:false}")
@@ -22,7 +27,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-organic}")
+  @Value("${app.sourceRepo}")
   private String sourceRepo;
 
   @Value("${git.commit.message.short:unknown}")
@@ -41,6 +46,8 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     .githubUrl(commitId != null && sourceRepo != null ? sourceRepo + "/commits/" + commitId : null)
     .build();
   log.info("getSystemInfo returns {}",si);
+  //System.out.println(sourceRepo);
+  log.info("sourceRepo = {}", sourceRepo);
   return si;
   }
 

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -22,17 +22,14 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${app.sourceRepo}")
-  private String sourceRepo = "https://github.com/ucsb-cs156/proj-organic";
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-organic}")
+  private String sourceRepo;
 
-  //@Value("${git.commit.message.short}")
-  private String commitMessage = "PLACEHOLDER";
+  @Value("${git.commit.message.short:unknown}")
+  private String commitMessage;
 
-  //@Value("${git.branch}")
-  private String branch = "PLACEHOLDER";
-
-  //@Value("${git.commit.id}")
-  private String commitId = "PLACEHOLDER";
+  @Value("${git.commit.id.abbrev:unknown}")
+  private String commitId;
 
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -1,7 +1,5 @@
 package edu.ucsb.cs156.organic.services;
 
-//import io.github.cdimascio.dotenv.Dotenv;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -18,8 +16,7 @@ import edu.ucsb.cs156.organic.models.SystemInfo;
 @Service("systemInfo")
 @ConfigurationProperties
 @PropertySources({
-  @PropertySource("classpath:git.properties"),
-  @PropertySource("classpath:application.properties")
+  @PropertySource("classpath:git.properties")
 })
 public class SystemInfoServiceImpl extends SystemInfoService {
   
@@ -28,9 +25,6 @@ public class SystemInfoServiceImpl extends SystemInfoService {
 
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
-
-  @Value("${app.admin.githubLogins}")
-  private String adminLogins;
 
   @Value("${app.sourceRepo}")
   private String sourceRepo;
@@ -53,9 +47,6 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     .githubUrl(commitId != null && sourceRepo != null ? sourceRepo + "/commits/" + commitId : null)
     .build();
   log.info("getSystemInfo returns {}",si);
-  //System.out.println(sourceRepo);
-  log.info("adminLogins = {}",adminLogins);
-  log.info("sourceRepo = {}", sourceRepo);
   return si;
   }
 

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -40,8 +40,6 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   }
 
   public SystemInfo getSystemInfo() {
-    //Dotenv dotenv = Dotenv.load();
-    //if (dotenv.get("REPOSITORY") != null) { sourceRepo = dotenv.get("REPOSITORY"); }
     SystemInfo si = SystemInfo.builder()
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
     .showSwaggerUILink(this.showSwaggerUILink)

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -30,6 +30,10 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
     .showSwaggerUILink(this.showSwaggerUILink)
     .sourceRepo(this.sourceRepo)
+    .commitMessage(this.commitMessage)
+    .branch(this.branch)
+    .commitId(this.commitId)
+    .githubUrl(commitId != null && soruceRepo != null ? soruceRepo + "/commits/" + commitId : null)
     .build();
   log.info("getSystemInfo returns {}",si);
   return si;

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -25,6 +25,15 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.sourceRepo}")
   private String sourceRepo = "https://github.com/ucsb-cs156/proj-organic";
 
+  //@Value("${git.commit.message.short}")
+  private String commitMessage = "PLACEHOLDER";
+
+  //@Value("${git.branch}")
+  private String branch = "PLACEHOLDER";
+
+  //@Value("${git.commit.id}")
+  private String commitId = "PLACEHOLDER";
+
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
@@ -33,7 +42,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     .commitMessage(this.commitMessage)
     .branch(this.branch)
     .commitId(this.commitId)
-    .githubUrl(commitId != null && soruceRepo != null ? soruceRepo + "/commits/" + commitId : null)
+    .githubUrl(commitId != null && sourceRepo != null ? sourceRepo + "/commits/" + commitId : null)
     .build();
   log.info("getSystemInfo returns {}",si);
   return si;

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -37,7 +37,6 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     .showSwaggerUILink(this.showSwaggerUILink)
     .sourceRepo(this.sourceRepo)
     .commitMessage(this.commitMessage)
-    .branch(this.branch)
     .commitId(this.commitId)
     .githubUrl(commitId != null && sourceRepo != null ? sourceRepo + "/commits/" + commitId : null)
     .build();

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -25,7 +25,6 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.sourceRepo}")
   private String sourceRepo = "https://github.com/ucsb-cs156/proj-organic";
 
-<<<<<<< HEAD
   //@Value("${git.commit.message.short}")
   private String commitMessage = "PLACEHOLDER";
 
@@ -34,16 +33,6 @@ public class SystemInfoServiceImpl extends SystemInfoService {
 
   //@Value("${git.commit.id}")
   private String commitId = "PLACEHOLDER";
-=======
-  @Value("${git.commit.message.short}")
-  private String commitMessage = "PLACEHOLDER";
-
-  @Value("${git.branch}")
-  private String branch = "PLACEHOLDER";
-
-  @Value("${git.commit.id}")
-  private String commitIde = "PLACEHOLDER";
->>>>>>> c835d39ce311ae6427228e10e7d1151fd39965a0
 
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -35,6 +35,10 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${git.commit.id.abbrev:unknown}")
   private String commitId;
 
+  public static String githubUrl(String repo, String commit) {
+    return commit != null && repo != null ? repo + "/commit/" + commit : null;
+  }
+
   public SystemInfo getSystemInfo() {
     //Dotenv dotenv = Dotenv.load();
     //if (dotenv.get("REPOSITORY") != null) { sourceRepo = dotenv.get("REPOSITORY"); }
@@ -44,7 +48,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     .sourceRepo(this.sourceRepo)
     .commitMessage(this.commitMessage)
     .commitId(this.commitId)
-    .githubUrl(commitId != null && sourceRepo != null ? sourceRepo + "/commits/" + commitId : null)
+    .githubUrl(githubUrl(sourceRepo, commitId))
     .build();
   log.info("getSystemInfo returns {}",si);
   return si;

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -25,6 +25,15 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.sourceRepo}")
   private String sourceRepo = "https://github.com/ucsb-cs156/proj-organic";
 
+  @Value("${git.commit.message.short}")
+  private String commitMessage = "PLACEHOLDER";
+
+  @Value("${git.branch}")
+  private String branch = "PLACEHOLDER";
+
+  @Value("${git.commit.id}")
+  private String commitIde = "PLACEHOLDER";
+
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
@@ -33,7 +42,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     .commitMessage(this.commitMessage)
     .branch(this.branch)
     .commitId(this.commitId)
-    .githubUrl(commitId != null && soruceRepo != null ? soruceRepo + "/commits/" + commitId : null)
+    .githubUrl(commitId != null && sourceRepo != null ? sourceRepo + "/commits/" + commitId : null)
     .build();
   log.info("getSystemInfo returns {}",si);
   return si;

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -10,7 +10,7 @@ spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
 app.showSwaggerUILink=true
-app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-organic}}
+app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:phtcon@ucsb.edu}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -10,7 +10,7 @@ spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
 app.showSwaggerUILink=true
-app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:phtcon@ucsb.edu}}
+app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:github.com/ucsb-cs156/proj-organic}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -2,8 +2,6 @@ spring.datasource.url=${JDBC_DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
-
 spring.liquibase.url=${JDBC_DATABASE_URL}
 spring.liquibase.user=${JDBC_DATABASE_USERNAME}
 spring.liquibase.password=${JDBC_DATABASE_PASSWORD}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,7 +31,7 @@ management.endpoints.web.exposure.include=mappings
 springdoc.swagger-ui.csrf.enabled=true
 
 app.admin.githubLogins=${ADMIN_GITHUB_LOGINS:${env.ADMIN_GITHUB_LOGINS:phtcon@ucsb.edu}}
-app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:phtcon@ucsb.edu}}
+app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:github.com/ucsb-cs156/proj-organic}}
 
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,7 +31,7 @@ management.endpoints.web.exposure.include=mappings
 springdoc.swagger-ui.csrf.enabled=true
 
 app.admin.githubLogins=${ADMIN_GITHUB_LOGINS:${env.ADMIN_GITHUB_LOGINS:phtcon@ucsb.edu}}
-app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-organic}}
+app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:phtcon@ucsb.edu}}
 
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false

--- a/src/test/java/edu/ucsb/cs156/organic/interceptors/RoleUserInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/interceptors/RoleUserInterceptorTests.java
@@ -16,7 +16,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import edu.ucsb.cs156.organic.entities.User;
-import edu.ucsb.cs156.organic.interceptors.RoleUserInterceptor;
+import edu.ucsb.cs156.organic.intercepters.RoleUserInterceptor;
 import edu.ucsb.cs156.organic.controllers.ControllerTestCase;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/edu/ucsb/cs156/organic/interceptors/RoleUserInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/interceptors/RoleUserInterceptorTests.java
@@ -16,7 +16,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import edu.ucsb.cs156.organic.entities.User;
-import edu.ucsb.cs156.organic.intercepters.RoleUserInterceptor;
+import edu.ucsb.cs156.organic.interceptors.RoleUserInterceptor;
 import edu.ucsb.cs156.organic.controllers.ControllerTestCase;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImplTests.java
@@ -2,10 +2,15 @@ package edu.ucsb.cs156.organic.services;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -15,7 +20,6 @@ import edu.ucsb.cs156.organic.models.SystemInfo;
 // The unit under test relies on property values
 // For hints on testing, see: https://www.baeldung.com/spring-boot-testing-configurationproperties
 
-
 @ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties(value = SystemInfoServiceImpl.class)
 @TestPropertySource("classpath:application-development.properties")
@@ -24,12 +28,28 @@ class SystemInfoServiceImplTests  {
   @Autowired
   private SystemInfoService systemInfoService;
 
+  @Value("${app.sourceRepo}")
+  private String sourceRepo; 
+
   @Test
   void test_getSystemInfo() {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
-    assertEquals("https://github.com/ucsb-cs156/proj-organic", si.getSourceRepo());
+    assertEquals(sourceRepo, si.getSourceRepo());
+    assertTrue(si.getGithubUrl().startsWith(si.getSourceRepo()));
+    assertTrue(si.getGithubUrl().endsWith(si.getCommitId()));
+    assertTrue(si.getGithubUrl().contains("/commit/"));
   }
 
+  @Test
+  void test_githubUrl() {
+    assertEquals(
+        SystemInfoServiceImpl.githubUrl(
+            "https://github.com/ucsb-cs156/proj-courses", "abcdef12345"),
+        "https://github.com/ucsb-cs156/proj-courses/commit/abcdef12345");
+    assertNull(SystemInfoServiceImpl.githubUrl(null, null));
+    assertNull(SystemInfoServiceImpl.githubUrl("x", null));
+    assertNull(SystemInfoServiceImpl.githubUrl(null, "x"));
+  }
 }


### PR DESCRIPTION
In this PR, we modified the System Info model and service implementation so that when you visit /api/systemInfo, you'll additionally obtain information about the latest commit that is running, including id, message, and a url to that commit on github.com.

Here's what it looks like (at least on localhost):
![Screenshot 2024-05-27 190814](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-1/assets/50055753/0c57c6af-afa6-454a-a697-c5f3d8558ec5)

The source Repo value is set by an environment variable, so make sure to set 
`SOURCE_REPO=github.com/ucsb-cs156-s24/proj-organic-s24-5pm-1`
in your .env file if you're running this in your local machine or run
`dokku git:set <your dokku instance name> keep-git-dir true` and
`dokku config:set --no-restart <your dokku instance name> SOURCE_REPO=github.com/ucsb-cs156-s24/proj-organic-s24-5pm-1`
if you're doing this on dokku.

You can check this out for yourself: [proj-organic-rtzhang1x-dev.dokku-09.cs.ucsb.edu/api/systemInfo](https://proj-organic-rtzhang1x-dev.dokku-09.cs.ucsb.edu/api/systemInfo)

Closes #4.