### PR TITLE
Create Student Table (but no interface to view it yet)

### DIFF
--- a/frontend/src/fixtures/studentFixture.js
+++ b/frontend/src/fixtures/studentFixture.js
@@ -1,0 +1,45 @@
+const studentFixture = {
+
+    oneStudent: {
+        "id": 1,
+        "courseId": 1,
+        "fname": "Unimportant",
+        "lname": "Student",
+        "studentId": "1000000",
+        "email": "unimportantstudent@unimportant.com",
+        "githubId": "unimportantstudent"
+    },
+
+    threeStudents: [
+        {
+            "id": 1,
+            "courseId": 1,
+            "fname": "Unimportant",
+            "lname": "Student",
+            "studentId": "1000000",
+            "email": "unimportantstudent@unimportant.com",
+            "githubId": "unimportantstudent"
+        },
+        {
+            "id": 2,
+            "courseId": 2,
+            "fname": "Unimportant",
+            "lname": "Student II",
+            "studentId": "1000001",
+            "email": "anotherunimportantstudent@unimportant.com",
+            "githubId": "aaaaaaaahhhh"
+        },
+        {
+            "id": 3,
+            "courseId": 2,
+            "fname": "Unimportant",
+            "lname": "Student III",
+            "studentId": "9999999",
+            "email": "unimportant3student@unimportant.com",
+            "githubId": "studentimportantun"
+        },
+    ]
+};
+
+
+export { studentFixture };

--- a/frontend/src/main/components/Student/StudentTable.js
+++ b/frontend/src/main/components/Student/StudentTable.js
@@ -34,10 +34,6 @@ import OurTable from "main/components/OurTable"
          {
             Header: 'email',
             accessor: 'email',
-         },
-         {
-            Header: 'githubId',
-            accessor: 'githubId',
          }
   
      ];

--- a/frontend/src/main/components/Student/StudentTable.js
+++ b/frontend/src/main/components/Student/StudentTable.js
@@ -2,7 +2,7 @@ import React from "react";
 import OurTable from "main/components/OurTable"
 
 
- export default function StaffTable({ students }) {
+ export default function StudentTable({ students }) {
 
      // Stryker disable next-line all : TODO try to make a good test for this
 

--- a/frontend/src/main/components/Student/StudentTable.js
+++ b/frontend/src/main/components/Student/StudentTable.js
@@ -1,0 +1,49 @@
+import React from "react";
+import OurTable from "main/components/OurTable"
+
+
+ export default function StaffTable({ students }) {
+
+     // Stryker disable next-line all : TODO try to make a good test for this
+
+     const columns = [
+         {
+             Header: 'id',
+             accessor: 'id',
+         },
+         {
+             Header: 'courseId',
+             accessor: 'courseId',
+         },
+         {
+             Header: 'githubId',
+             accessor: 'githubId',
+         },
+         {
+             Header: 'fname',
+             accessor: 'fname',
+         },
+         {
+            Header: 'lname',
+            accessor: 'lname',
+         },
+         {
+            Header: 'studentId',
+            accessor:'studentId',
+         },
+         {
+            Header: 'email',
+            accessor: 'email',
+         },
+         {
+            Header: 'githubId',
+            accessor: 'githubId',
+         }
+  
+     ];
+
+     return <OurTable
+         data={students}
+         columns={columns}
+         testid={"StudentTable"} />;
+    };

--- a/frontend/src/stories/components/Student/StudentTable.stories.js
+++ b/frontend/src/stories/components/Student/StudentTable.stories.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import StudentTable from 'main/components/Student/StudentTable';
+import { studentFixture } from 'fixtures/studentFixture';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { rest } from "msw";
+
+export default {
+    title: 'components/Student/StudentTable',
+    component: StudentTable
+};
+
+const Template = (args) => {
+    return (
+        <StudentTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    student: []
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+    student: studentFixture.threeStudent,
+    currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+    student: studentFixture.threeStudent,
+    currentUser: currentUserFixtures.adminUser,
+}
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.delete('/api/course/student/all', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+};

--- a/frontend/src/stories/components/Student/StudentTable.stories.js
+++ b/frontend/src/stories/components/Student/StudentTable.stories.js
@@ -18,19 +18,19 @@ const Template = (args) => {
 export const Empty = Template.bind({});
 
 Empty.args = {
-    student: []
+    students: []
 };
 
 export const ThreeItemsOrdinaryUser = Template.bind({});
 
 ThreeItemsOrdinaryUser.args = {
-    student: studentFixture.threeStudent,
+    students: studentFixture.threeStudents,
     currentUser: currentUserFixtures.userOnly,
 };
 
 export const ThreeItemsAdminUser = Template.bind({});
 ThreeItemsAdminUser.args = {
-    student: studentFixture.threeStudent,
+    students: studentFixture.threeStudents,
     currentUser: currentUserFixtures.adminUser,
 }
 

--- a/frontend/src/tests/components/Student/StudentTable.test.js
+++ b/frontend/src/tests/components/Student/StudentTable.test.js
@@ -1,0 +1,158 @@
+import StudentTable from "main/components/Student/StudentTable"
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+// import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import {  render, screen } from "@testing-library/react";
+import { studentFixture } from "fixtures/studentFixture";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("StudentTable tests", () => {
+  const queryClient = new QueryClient();
+  const expectedHeaders = ["id", "courseId", "githubId", "fname", "lname", "studentId", "email"];
+  const expectedFields = ["id", "courseId", "githubId", "fname", "lname", "studentId", "email"]; 
+  const testId = "StudentTable";
+
+  test("Has the expected column headers and content for ordinary user", () => {
+
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <StudentTable student={studentFixture.threeStudent} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedStudentgithub = studentFixture.threeStudent;
+    expectedStudentgithub.forEach((studentMember, index) => {
+      const githubIdCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-githubId`);
+      expect(githubIdCell).toHaveTextContent(studentMember.githubId);
+    });
+
+    const expectedStudentcourse = studentFixture.threeStudent;
+    expectedStudentcourse.forEach((studentMember, index) => {
+      const courseIdCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-courseId`);
+      expect(courseIdCell).toHaveTextContent(studentMember.courseId);
+    });
+
+    const expectedStudentFname = studentFixture.threeStudent;
+    expectedStudentcourse.forEach((studentMember, index) => {
+      const fnameCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-fname`);
+      expect(fnameCell).toHaveTextContent(studentMember.fname);
+    });
+
+    const expectedStudentLname = studentFixture.threeStudent;
+    expectedStudentcourse.forEach((studentMember, index) => {
+      const lnameCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-lname`);
+      expect(lnameCell).toHaveTextContent(studentMember.lname);
+    });
+
+    const expectedStudentId = studentFixture.threeStudent;
+    expectedStudentcourse.forEach((studentMember, index) => {
+      const studentIdCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-studentId`);
+      expect(studentIdCell).toHaveTextContent(studentMember.studentId);
+    });
+
+    const expectedStudentemail = studentFixture.threeStudent;
+    expectedStudentcourse.forEach((studentMember, index) => {
+      const emailCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-email`);
+      expect(emailCell).toHaveTextContent(studentMember.email);
+    });
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+
+    
+    const editButton = screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).not.toBeInTheDocument();
+
+    const deleteButton = screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).not.toBeInTheDocument();
+
+  });
+
+  test("renders empty table correctly", () => {
+
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+
+    // act
+    render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+          <StudentTable student={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+
+  test("Has the expected colum headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+            <StudentTable student={studentFixture.threeStudent} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    // const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    // expect(deleteButton).toBeInTheDocument();
+    // expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+  
+});

--- a/frontend/src/tests/components/Student/StudentTable.test.js
+++ b/frontend/src/tests/components/Student/StudentTable.test.js
@@ -46,25 +46,25 @@ describe("StudentTable tests", () => {
     });
 
     const expectedStudentFname = studentFixture.threeStudents;
-    expectedStudentcourse.forEach((studentMember, index) => {
+    expectedStudentFname.forEach((studentMember, index) => {
       const fnameCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-fname`);
       expect(fnameCell).toHaveTextContent(studentMember.fname);
     });
 
     const expectedStudentLname = studentFixture.threeStudents;
-    expectedStudentcourse.forEach((studentMember, index) => {
+    expectedStudentLname.forEach((studentMember, index) => {
       const lnameCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-lname`);
       expect(lnameCell).toHaveTextContent(studentMember.lname);
     });
 
     const expectedStudentId = studentFixture.threeStudents;
-    expectedStudentcourse.forEach((studentMember, index) => {
+    expectedStudentId.forEach((studentMember, index) => {
       const studentIdCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-studentId`);
       expect(studentIdCell).toHaveTextContent(studentMember.studentId);
     });
 
     const expectedStudentemail = studentFixture.threeStudents;
-    expectedStudentcourse.forEach((studentMember, index) => {
+    expectedStudentemail.forEach((studentMember, index) => {
       const emailCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-email`);
       expect(emailCell).toHaveTextContent(studentMember.email);
     });

--- a/frontend/src/tests/components/Student/StudentTable.test.js
+++ b/frontend/src/tests/components/Student/StudentTable.test.js
@@ -1,6 +1,5 @@
 import StudentTable from "main/components/Student/StudentTable"
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
-// import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import {  render, screen } from "@testing-library/react";
 import { studentFixture } from "fixtures/studentFixture";
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -148,10 +147,6 @@ describe("StudentTable tests", () => {
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-
-    // const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-    // expect(deleteButton).toBeInTheDocument();
-    // expect(deleteButton).toHaveClass("btn-danger");
 
   });
   

--- a/frontend/src/tests/components/Student/StudentTable.test.js
+++ b/frontend/src/tests/components/Student/StudentTable.test.js
@@ -27,43 +27,43 @@ describe("StudentTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <StudentTable student={studentFixture.threeStudent} currentUser={currentUser} />
+          <StudentTable students={studentFixture.threeStudents} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
     );
 
-    const expectedStudentgithub = studentFixture.threeStudent;
+    const expectedStudentgithub = studentFixture.threeStudents;
     expectedStudentgithub.forEach((studentMember, index) => {
       const githubIdCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-githubId`);
       expect(githubIdCell).toHaveTextContent(studentMember.githubId);
     });
 
-    const expectedStudentcourse = studentFixture.threeStudent;
+    const expectedStudentcourse = studentFixture.threeStudents;
     expectedStudentcourse.forEach((studentMember, index) => {
       const courseIdCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-courseId`);
       expect(courseIdCell).toHaveTextContent(studentMember.courseId);
     });
 
-    const expectedStudentFname = studentFixture.threeStudent;
+    const expectedStudentFname = studentFixture.threeStudents;
     expectedStudentcourse.forEach((studentMember, index) => {
       const fnameCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-fname`);
       expect(fnameCell).toHaveTextContent(studentMember.fname);
     });
 
-    const expectedStudentLname = studentFixture.threeStudent;
+    const expectedStudentLname = studentFixture.threeStudents;
     expectedStudentcourse.forEach((studentMember, index) => {
       const lnameCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-lname`);
       expect(lnameCell).toHaveTextContent(studentMember.lname);
     });
 
-    const expectedStudentId = studentFixture.threeStudent;
+    const expectedStudentId = studentFixture.threeStudents;
     expectedStudentcourse.forEach((studentMember, index) => {
       const studentIdCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-studentId`);
       expect(studentIdCell).toHaveTextContent(studentMember.studentId);
     });
 
-    const expectedStudentemail = studentFixture.threeStudent;
+    const expectedStudentemail = studentFixture.threeStudents;
     expectedStudentcourse.forEach((studentMember, index) => {
       const emailCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-email`);
       expect(emailCell).toHaveTextContent(studentMember.email);
@@ -102,7 +102,7 @@ describe("StudentTable tests", () => {
     render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter>
-          <StudentTable student={[]} currentUser={currentUser} />
+          <StudentTable students={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
     );
@@ -129,7 +129,7 @@ describe("StudentTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-            <StudentTable student={studentFixture.threeStudent} currentUser={currentUser} />
+            <StudentTable students={studentFixture.threeStudents} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 


### PR DESCRIPTION
In this PR, we created the React component for displaying student data from the /api/students/all endpoint and its corresponding tests and storybook. I have yet to create an interface to actaully display the data.

Closes #12.
