### PR TITLE
Course Show Page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -43,7 +43,7 @@ function App() {
       <Route path="/courses/create" element={<CoursesCreatePage />} />
       <Route path="/courses" element={<CourseIndexPage />} />
       <Route path="/courses/edit/:id" element={<CoursesEditPage />} />
-      <Route path="/courses/:id" element={<CoursesShowPage />} />
+      <Route path="/courses/show/:id" element={<CoursesShowPage />} />
     </>
   ) : null;
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,7 +7,6 @@ import HomePage from "main/pages/HomePage";
 import LoadingPage from "main/pages/LoadingPage";
 import LoginPage from "main/pages/LoginPage";
 import ProfilePage from "main/pages/ProfilePage";
-import CoursesEditPage from "main/pages/CoursesEditPage";
 
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminJobsPage from "main/pages/AdminJobsPage";
@@ -15,6 +14,8 @@ import SchoolIndexPage from "main/pages/SchoolIndexPage";
 
 import CoursesCreatePage from "main/pages/CoursesCreatePage";
 import CourseIndexPage from "main/pages/CourseIndexPage";
+import CoursesEditPage from "main/pages/CoursesEditPage";
+import CoursesShowPage from "main/pages/CoursesShowPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import NotFoundPage from "main/pages/NotFoundPage";
@@ -42,6 +43,7 @@ function App() {
       <Route path="/courses/create" element={<CoursesCreatePage />} />
       <Route path="/courses" element={<CourseIndexPage />} />
       <Route path="/courses/edit/:id" element={<CoursesEditPage />} />
+      <Route path="/courses/:id" element={<CoursesShowPage />} />
     </>
   ) : null;
 

--- a/frontend/src/main/components/Courses/CoursesTable.js
+++ b/frontend/src/main/components/Courses/CoursesTable.js
@@ -71,13 +71,13 @@ export default function CoursesTable({ courses, currentUser }) {
     ];
 
     if (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) {
-        columns.push(ButtonColumn("Show", "primary", courseCallback, "CoursesTable"));
+        columns.push(ButtonColumn("Show", "#FFA500", courseCallback, "CoursesTable"));
         columns.push(ButtonColumn("Staff", "primary", staffCallback, "CoursesTable"));
-        columns.push(ButtonColumn("Edit", "primary", editCallback, "CoursesTable"));
+        columns.push(ButtonColumn("Edit", "#AAFF00", editCallback, "CoursesTable"));
         columns.push(ButtonColumn("Delete", "danger", deleteCallback, "CoursesTable"));
     }
 
-    columns.push(ButtonColumn("Join", "primary", joinCallback, "CoursesTable"));
+    columns.push(ButtonColumn("Join", "#BF40BF", joinCallback, "CoursesTable"));
 
 
 

--- a/frontend/src/main/components/Courses/CoursesTable.js
+++ b/frontend/src/main/components/Courses/CoursesTable.js
@@ -1,85 +1,100 @@
 import React from "react";
- import OurTable, { ButtonColumn } from "main/components/OurTable"
- import { useBackendMutation } from "main/utils/useBackend";
- import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/components/Utils/CoursesUtils"
- import { useNavigate } from "react-router-dom";
- import { hasRole } from "main/utils/currentUser";
+import OurTable, { ButtonColumn } from "main/components/OurTable"
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/components/Utils/CoursesUtils"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
 
- export default function CoursesTable({ courses, currentUser }) {
+export default function CoursesTable({ courses, currentUser }) {
 
-     const navigate = useNavigate();
+    const navigate = useNavigate();
 
-     const joinCallback = (cell) => {
+    const joinCallback = (cell) => {
         navigate(`/courses/join/${cell.row.values.id}`);
     };
 
-     const staffCallback = (cell) => {
+    const staffCallback = (cell) => {
         navigate(`/courses/${cell.row.values.id}/staff`);
     };
 
-     const editCallback = (cell) => {
-         navigate(`/courses/edit/${cell.row.values.id}`);
-     };
+    const editCallback = (cell) => {
+        navigate(`/courses/edit/${cell.row.values.id}`);
+    };
 
-     // Stryker disable all : hard to test for query caching
+    const courseCallback = (cell) => {
+        navigate(`/courses/${cell.row.values.id}`);
+    };
 
-     const deleteMutation = useBackendMutation(
-         cellToAxiosParamsDelete,
-         { onSuccess: onDeleteSuccess },
-         ["/api/courses/all"]
-     );
-     // Stryker restore all 
+    // Stryker disable all : hard to test for query caching
 
-     // Stryker disable next-line all : TODO try to make a good test for this
-     const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/courses/all"]
+    );
+    // Stryker restore all 
 
-     const columns = [
-         {
-             Header: 'id',
-             accessor: 'id',
-         },
-         {
-             Header: 'Name',
-             accessor: 'name',
-         },
-         {
-             Header: 'School',
-             accessor: 'school',
-         },
-         {
-             Header: 'Term',
-             accessor: 'term',
-         },
-         {
-             Header: 'StartDate',
-             accessor: 'startDate',
-         },
-         {
-             Header: 'EndDate',
-             accessor: 'endDate',
-         },
-         {
-             Header: 'GitHub Org',
-             accessor: 'githubOrg',
-         },
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
 
-  
-     ];
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id',
+            Cell: ({ cell }) => (
+                <a
+                    href={`/courses/${cell.value}`}
+                    onClick={(e) => {
+                        e.preventDefault();
+                         courseCallback(cell);
+                    }}
+                >
+                    {cell.value}
+                </a>
+            )
+        },
+        {
+            Header: 'Name',
+            accessor: 'name',
+        },
+        {
+            Header: 'School',
+            accessor: 'school',
+        },
+        {
+            Header: 'Term',
+            accessor: 'term',
+        },
+        {
+            Header: 'StartDate',
+            accessor: 'startDate',
+        },
+        {
+            Header: 'EndDate',
+            accessor: 'endDate',
+        },
+        {
+            Header: 'GitHub Org',
+            accessor: 'githubOrg',
+        },
 
-     if (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) {
-         columns.push(ButtonColumn("Staff", "primary", staffCallback, "CoursesTable"));
-         columns.push(ButtonColumn("Edit", "primary", editCallback, "CoursesTable"));
-         columns.push(ButtonColumn("Delete", "danger", deleteCallback, "CoursesTable"));
-     }
-     
-     columns.push(ButtonColumn("Join", "primary", joinCallback, "CoursesTable"));
+
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) {
+        columns.push(ButtonColumn("Staff", "primary", staffCallback, "CoursesTable"));
+        columns.push(ButtonColumn("Edit", "primary", editCallback, "CoursesTable"));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "CoursesTable"));
+    }
+
+    columns.push(ButtonColumn("Join", "primary", joinCallback, "CoursesTable"));
 
 
 
-     return (
+    return (
         <>
             <div>Total Courses: {courses.length}</div>
-          <OurTable data={courses} columns={columns} testid={"CoursesTable"} />
+            <OurTable data={courses} columns={columns} testid={"CoursesTable"} />
         </>
-      );
-    };
+    );
+};

--- a/frontend/src/main/components/Courses/CoursesTable.js
+++ b/frontend/src/main/components/Courses/CoursesTable.js
@@ -22,7 +22,7 @@ export default function CoursesTable({ courses, currentUser }) {
     };
 
     const courseCallback = (cell) => {
-        navigate(`/courses/${cell.row.values.id}`);
+        navigate(`/courses/show/${cell.row.values.id}`);
     };
 
     // Stryker disable all : hard to test for query caching
@@ -41,17 +41,6 @@ export default function CoursesTable({ courses, currentUser }) {
         {
             Header: 'id',
             accessor: 'id',
-            Cell: ({ cell }) => (
-                <a
-                    href={`/courses/${cell.value}`}
-                    onClick={(e) => {
-                        e.preventDefault();
-                         courseCallback(cell);
-                    }}
-                >
-                    {cell.value}
-                </a>
-            )
         },
         {
             Header: 'Name',
@@ -82,6 +71,7 @@ export default function CoursesTable({ courses, currentUser }) {
     ];
 
     if (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) {
+        columns.push(ButtonColumn("Show", "primary", courseCallback, "CoursesTable"));
         columns.push(ButtonColumn("Staff", "primary", staffCallback, "CoursesTable"));
         columns.push(ButtonColumn("Edit", "primary", editCallback, "CoursesTable"));
         columns.push(ButtonColumn("Delete", "danger", deleteCallback, "CoursesTable"));

--- a/frontend/src/main/components/Courses/CoursesTable.js
+++ b/frontend/src/main/components/Courses/CoursesTable.js
@@ -71,13 +71,13 @@ export default function CoursesTable({ courses, currentUser }) {
     ];
 
     if (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) {
-        columns.push(ButtonColumn("Show", "#FFA500", courseCallback, "CoursesTable"));
+        columns.push(ButtonColumn("Show", "primary", courseCallback, "CoursesTable"));
         columns.push(ButtonColumn("Staff", "primary", staffCallback, "CoursesTable"));
-        columns.push(ButtonColumn("Edit", "#AAFF00", editCallback, "CoursesTable"));
+        columns.push(ButtonColumn("Edit", "primary", editCallback, "CoursesTable"));
         columns.push(ButtonColumn("Delete", "danger", deleteCallback, "CoursesTable"));
     }
 
-    columns.push(ButtonColumn("Join", "#BF40BF", joinCallback, "CoursesTable"));
+    columns.push(ButtonColumn("Join", "primary", joinCallback, "CoursesTable"));
 
 
 

--- a/frontend/src/main/components/Courses/ShowTable.js
+++ b/frontend/src/main/components/Courses/ShowTable.js
@@ -1,0 +1,63 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function ShowTable({ courses, currentUser }) {
+
+    const navigate = useNavigate();
+
+    const staffCallback = (cell) => {
+        navigate(`/courses/${cell.row.values.id}/staff`);
+    };
+
+    const editCallback = (cell) => {
+        navigate(`/courses/edit/${cell.row.values.id}`);
+    };
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id',
+        },
+        {
+            Header: 'Name',
+            accessor: 'name',
+        },
+        {
+            Header: 'School',
+            accessor: 'school',
+        },
+        {
+            Header: 'Term',
+            accessor: 'term',
+        },
+        {
+            Header: 'StartDate',
+            accessor: 'startDate',
+        },
+        {
+            Header: 'EndDate',
+            accessor: 'endDate',
+        },
+        {
+            Header: 'GitHub Org',
+            accessor: 'githubOrg',
+        },
+
+
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) {
+        columns.push(ButtonColumn("Staff", "primary", staffCallback, "ShowTable"));
+        columns.push(ButtonColumn("Edit", "#AAFF00", editCallback, "ShowTable"));
+    }
+
+
+    return (
+        <>
+            <div>Total Courses: {courses.length}</div>
+            <OurTable data={courses} columns={columns} testid={"ShowTable"} />
+        </>
+    );
+};

--- a/frontend/src/main/components/Courses/ShowTable.js
+++ b/frontend/src/main/components/Courses/ShowTable.js
@@ -1,5 +1,7 @@
 import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable"
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/components/Utils/CoursesUtils"
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
@@ -52,6 +54,7 @@ export default function ShowTable({ courses, currentUser }) {
         columns.push(ButtonColumn("Staff", "primary", staffCallback, "ShowTable"));
         columns.push(ButtonColumn("Edit", "#AAFF00", editCallback, "ShowTable"));
     }
+
 
 
     return (

--- a/frontend/src/main/components/Courses/ShowTable.js
+++ b/frontend/src/main/components/Courses/ShowTable.js
@@ -1,7 +1,5 @@
 import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable"
-import { useBackendMutation } from "main/utils/useBackend";
-import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/components/Utils/CoursesUtils"
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 

--- a/frontend/src/main/components/Courses/ShowTable.js
+++ b/frontend/src/main/components/Courses/ShowTable.js
@@ -53,11 +53,9 @@ export default function ShowTable({ courses, currentUser }) {
         columns.push(ButtonColumn("Edit", "#AAFF00", editCallback, "ShowTable"));
     }
 
-
-
     return (
         <>
-            <div>Total Courses: {courses.length}</div>
+            <div>Total Courses: {courses.length}</div> 
             <OurTable data={courses} columns={columns} testid={"ShowTable"} />
         </>
     );

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import CoursesTable from 'main/components/Courses/CoursesTable';
+import ShowTable from 'main/components/Courses/ShowTable';
 import { useBackend } from 'main/utils/useBackend';
 import { useCurrentUser } from 'main/utils/currentUser';
 
@@ -22,14 +22,13 @@ export default function CoursesShowPage() {
             },
             []
         );
-    console.log(courses);
          // Stryker restore all
 
     return (
         <BasicLayout>
             <div className="pt-2">
                 <h1>Individual Course Information</h1>
-                <CoursesTable courses={[courses]} currentUser={currentUser} />
+                <ShowTable courses={[courses]} currentUser={currentUser} />
                 <br></br>
                 <p>As an admin or instructor, you can navigate from the main courses page to a specific page for each course. This allows you to see a page dedicated to your specific course, which includes functionalities such as uploading the student roster, adding students or staff, and other course-related tasks. </p>
                 <br></br>

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -35,7 +35,7 @@ export default function CoursesShowPage() {
                 <br></br>
                 {/* Course Roster Upload Link */}
                 <p>
-                    <strong>Course Roster Upload:</strong>
+                    <strong>Course Roster:</strong>
                     <a href={`/courses/${id}/roster-upload`}>Upload Roster</a>
                 </p>
                 {/* Staff Roster */}

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -11,8 +11,8 @@ export default function CoursesShowPage() {
     const { data: currentUser } = useCurrentUser();
 
     const { data: courses, error: _error, status: _status } =
+        // Stryker disable all 
         useBackend(
-            // Stryker disable next-line all : don't test internal caching of React Query
             [],
             {
                 method: "GET", url: "/api/courses/get",
@@ -20,9 +20,9 @@ export default function CoursesShowPage() {
                     id
                 },
             },
-            // Stryker disable next-line all : don't test internal caching of React Query
             []
         );
+         // Stryker restore all
 
     return (
         <BasicLayout>

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -22,13 +22,14 @@ export default function CoursesShowPage() {
             },
             []
         );
+    console.log(courses);
          // Stryker restore all
 
     return (
         <BasicLayout>
             <div className="pt-2">
                 <h1>Individual Course Information</h1>
-                <CoursesTable courses={courses ? [courses] : []} currentUser={currentUser} />
+                <CoursesTable courses={[courses]} currentUser={currentUser} />
                 <br></br>
                 <p>As an admin or instructor, you can navigate from the /courses page to a specific page for each course. This allows you to see a page dedicated to your specific course, which includes functionalities such as uploading the student roster, adding students or staff, and other course-related tasks. </p>
                 <br></br>

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -31,7 +31,7 @@ export default function CoursesShowPage() {
                 <h1>Individual Course Information</h1>
                 <CoursesTable courses={[courses]} currentUser={currentUser} />
                 <br></br>
-                <p>As an admin or instructor, you can navigate from the /courses page to a specific page for each course. This allows you to see a page dedicated to your specific course, which includes functionalities such as uploading the student roster, adding students or staff, and other course-related tasks. </p>
+                <p>As an admin or instructor, you can navigate from the main courses page to a specific page for each course. This allows you to see a page dedicated to your specific course, which includes functionalities such as uploading the student roster, adding students or staff, and other course-related tasks. </p>
                 <br></br>
                 {/* Course Roster Upload Link */}
                 <p>

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -35,17 +35,17 @@ export default function CoursesShowPage() {
                 {/* Course Roster Upload Link */}
                 <p>
                     <strong>Course Roster:</strong>
-                    <a>Upload Roster</a>
+                    <p>Upload Roster</p>
                 </p>
                 {/* Staff Roster */}
                 <p>
                     <strong>Staff Roster:</strong>
-                    <a>View Staff</a>
+                    <p>View Staff</p>
                 </p>
                 {/* Student Roster */}
                 <p>
                     <strong>Student Roster:</strong>
-                    <a>View Students</a>
+                    <p>View Students</p>
                 </p>
             </div>
         </BasicLayout>

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -31,8 +31,10 @@ export default function CoursesShowPage() {
     return (
         <BasicLayout>
             <div className="pt-2">
-                <h1>Individual Course Details</h1>
+                <h1>Individual Course Information</h1>
                 <CoursesTable courses={checkLength} currentUser={currentUser} />
+                <br></br>
+                <p>As an admin or instructor, you can navigate from the /courses page to a specific page for each course. This allows you to see a page dedicated to your specific course, which includes functionalities such as uploading the student roster, adding students or staff, and other course-related tasks. </p>
                 <br></br>
                 {/* Course Roster Upload Link */}
               <p>

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -1,0 +1,39 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import CoursesForm from "main/components/Courses/CoursesForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function CoursesShowPage({storybook=false}) {
+  let { id } = useParams();
+
+  const { data: course, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/courses?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/courses/get`,
+        params: {
+          id
+        }
+      }
+    );
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/courses" />
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Course Information</h1>
+        {
+          course && <CoursesForm initialContents={course}/>
+        }
+        <p>This is the place to upload student roster, add student or staff, and to show course details</p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -1,57 +1,227 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import CoursesShowPage from "main/pages/CoursesShowPage";
 
-import React from 'react';
-import { useParams } from 'react-router-dom';
-import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import CoursesTable from 'main/components/Courses/CoursesTable';
-import { useBackend } from 'main/utils/useBackend';
-import { useCurrentUser } from 'main/utils/currentUser';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { coursesFixtures } from "fixtures/coursesFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
 
-export default function CoursesShowPage() {
-    let { id } = useParams();
-    const { data: currentUser } = useCurrentUser();
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
-    const { data: courses, error: _error, status: _status } =
-        useBackend(
-            [`/api/courses?id=${id}`],
-            {
-                method: "GET", url: "/api/courses/get",
-                params: {
-                    id
-                },
-            },
-    []
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("CoursesShowPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "CoursesTable";
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupInstructorUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.instructorUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    }
+
+    const setupUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    }
+
+    const renderCoursesShowPage = async (userSetup) => {
+        userSetup();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
         );
-        let checkLength = [];
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+    };
+
+    test("renders course correctly for admin", async () => {
+        await renderCoursesShowPage(setupAdminUser);
+    });
+
+    test("renders course correctly for instructor", async () => {
+        await renderCoursesShowPage(setupInstructorUser);
+    });
+
+    const renderAndAssertEmptyTable = async (userSetup) => {
+        userSetup();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).timeout();
+        const restoreConsole = mockConsole();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        restoreConsole();
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    };
+
+    test("renders empty table when backend unavailable, admin", async () => {
+        await renderAndAssertEmptyTable(setupAdminUser);
+    });
+
+    test("renders empty table when backend unavailable, instructor", async () => {
+        await renderAndAssertEmptyTable(setupInstructorUser);
+    });
+
+    const testDeleteCourse = async (userSetup) => {
+        userSetup();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+        axiosMock.onDelete("/api/courses/delete").reply(200, "Course with id 1 was deleted");
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Course with id 1 was deleted") });
+    };
+
+    test("what happens when you click delete, admin", async () => {
+        await testDeleteCourse(setupAdminUser);
+    });
+
+    test("what happens when you click delete, instructor", async () => {
+        await testDeleteCourse(setupInstructorUser);
+    });
+
+    test("tests buttons for editing do not show up for user", async () => {
+        setupUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+        const deleteButton = screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).not.toBeInTheDocument();
+    });
+
+    const checkLengthHelper = (courses) => {
+        let checkLength = courses;
         if (courses && courses.length !== 0) {
             checkLength = [courses];
-        } else if (courses) {
-            checkLength = courses;
         }
+        return checkLength;
+    };
 
-    return (
-        <BasicLayout>
-            <div className="pt-2">
-                <h1>Individual Course Information</h1>
-                <CoursesTable courses={checkLength} currentUser={currentUser} />
-                <br></br>
-                <p>As an admin or instructor, you can navigate from the /courses page to a specific page for each course. This allows you to see a page dedicated to your specific course, which includes functionalities such as uploading the student roster, adding students or staff, and other course-related tasks. </p>
-                <br></br>
-                {/* Course Roster Upload Link */}
-              <p>
-                <strong>Course Roster Upload:</strong>
-                <a href={`/courses/${id}/roster-upload`}>Upload Roster</a>
-              </p>
-              {/* Staff Roster */}
-              <p>
-                <strong>Staff Roster:</strong>
-                <a href={`/courses/${id}/staff-roster`}>View Staff</a>
-              </p>
-              {/* Student Roster */}
-              <p>
-                <strong>Student Roster:</strong>
-                <a href={`/courses/${id}/student-roster`}>View Students</a>
-              </p>
-            </div>
-        </BasicLayout>
-    );
-}
+    test("checkLength should contain courses if courses exists", () => {
+        const courses = [{ id: 1, name: "Test Course" }];
+        let checkLength = checkLengthHelper(courses);
+        expect(checkLength).toEqual([courses]);
+    });
+
+    test("checkLength should contain courses if courses exists but is empty", () => {
+        const courses = [];
+        let checkLength = checkLengthHelper(courses);
+        expect(checkLength).toEqual(courses);
+    });
+
+    test("throw a falsy value to courses?", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, 0);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    test("check that the course links are correct", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+    
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    
+        await waitFor(() => {
+            expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument();
+        });
+    
+        expect(screen.getByRole('link', { name: /Upload Roster/i })).toHaveAttribute('href', '/courses/17/roster-upload');
+        expect(screen.getByRole('link', { name: /View Staff/i })).toHaveAttribute('href', '/courses/17/staff-roster');
+        expect(screen.getByRole('link', { name: /View Students/i })).toHaveAttribute('href', '/courses/17/student-roster');
+    });
+
+});

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -35,17 +35,17 @@ export default function CoursesShowPage() {
                 {/* Course Roster Upload Link */}
                 <p>
                     <strong>Course Roster:</strong>
-                    <a href={`/courses/${id}/roster-upload`}>Upload Roster</a>
+                    <a>Upload Roster</a>
                 </p>
                 {/* Staff Roster */}
                 <p>
                     <strong>Staff Roster:</strong>
-                    <a href={`/courses/${id}/staff-roster`}>View Staff</a>
+                    <a>View Staff</a>
                 </p>
                 {/* Student Roster */}
                 <p>
                     <strong>Student Roster:</strong>
-                    <a href={`/courses/${id}/student-roster`}>View Students</a>
+                    <a>View Students</a>
                 </p>
             </div>
         </BasicLayout>

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -12,6 +12,7 @@ export default function CoursesShowPage() {
 
     const { data: courses, error: _error, status: _status } =
         useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
             [],
             {
                 method: "GET", url: "/api/courses/get",
@@ -19,6 +20,7 @@ export default function CoursesShowPage() {
                     id
                 },
             },
+            // Stryker disable next-line all : don't test internal caching of React Query
             []
         );
 

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -12,45 +12,39 @@ export default function CoursesShowPage() {
 
     const { data: courses, error: _error, status: _status } =
         useBackend(
-            [`/api/courses?id=${id}`],
+            [],
             {
                 method: "GET", url: "/api/courses/get",
                 params: {
                     id
                 },
             },
-    []
+            []
         );
-        let checkLength = [];
-        if (courses && courses.length !== 0) {
-            checkLength = [courses];
-        } else if (courses) {
-            checkLength = courses;
-        }
 
     return (
         <BasicLayout>
             <div className="pt-2">
                 <h1>Individual Course Information</h1>
-                <CoursesTable courses={checkLength} currentUser={currentUser} />
+                <CoursesTable courses={courses ? [courses] : []} currentUser={currentUser} />
                 <br></br>
                 <p>As an admin or instructor, you can navigate from the /courses page to a specific page for each course. This allows you to see a page dedicated to your specific course, which includes functionalities such as uploading the student roster, adding students or staff, and other course-related tasks. </p>
                 <br></br>
                 {/* Course Roster Upload Link */}
-              <p>
-                <strong>Course Roster Upload:</strong>
-                <a href={`/courses/${id}/roster-upload`}>Upload Roster</a>
-              </p>
-              {/* Staff Roster */}
-              <p>
-                <strong>Staff Roster:</strong>
-                <a href={`/courses/${id}/staff-roster`}>View Staff</a>
-              </p>
-              {/* Student Roster */}
-              <p>
-                <strong>Student Roster:</strong>
-                <a href={`/courses/${id}/student-roster`}>View Students</a>
-              </p>
+                <p>
+                    <strong>Course Roster Upload:</strong>
+                    <a href={`/courses/${id}/roster-upload`}>Upload Roster</a>
+                </p>
+                {/* Staff Roster */}
+                <p>
+                    <strong>Staff Roster:</strong>
+                    <a href={`/courses/${id}/staff-roster`}>View Staff</a>
+                </p>
+                {/* Student Roster */}
+                <p>
+                    <strong>Student Roster:</strong>
+                    <a href={`/courses/${id}/student-roster`}>View Students</a>
+                </p>
             </div>
         </BasicLayout>
     );

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -38,17 +38,17 @@ export default function CoursesShowPage() {
                 <br></br>
                 {/* Course Roster Upload Link */}
               <p>
-                <strong>Course Roster Upload:</strong>{" "}
+                <strong>Course Roster Upload:</strong>
                 <a href={`/courses/${id}/roster-upload`}>Upload Roster</a>
               </p>
               {/* Staff Roster */}
               <p>
-                <strong>Staff Roster:</strong>{" "}
+                <strong>Staff Roster:</strong>
                 <a href={`/courses/${id}/staff-roster`}>View Staff</a>
               </p>
               {/* Student Roster */}
               <p>
-                <strong>Student Roster:</strong>{" "}
+                <strong>Student Roster:</strong>
                 <a href={`/courses/${id}/student-roster`}>View Students</a>
               </p>
             </div>

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -1,39 +1,55 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import { useParams } from "react-router-dom";
-import CoursesForm from "main/components/Courses/CoursesForm";
-import { Navigate } from 'react-router-dom'
-import { useBackend, useBackendMutation } from "main/utils/useBackend";
-import { toast } from "react-toastify";
+import CoursesTable from 'main/components/Courses/CoursesTable';
+import { useBackend } from 'main/utils/useBackend';
+import { useCurrentUser } from 'main/utils/currentUser';
 
-export default function CoursesShowPage({storybook=false}) {
-  let { id } = useParams();
+export default function CoursesShowPage() {
+    let { id } = useParams();
+    const { data: currentUser } = useCurrentUser();
 
-  const { data: course, _error, _status } =
-    useBackend(
-      // Stryker disable next-line all : don't test internal caching of React Query
-      [`/api/courses?id=${id}`],
-      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
-        method: "GET",
-        url: `/api/courses/get`,
-        params: {
-          id
-        }
-      }
-    );
+    const { data: course, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/courses/show?id=${id}`],
 
-  if (isSuccess && !storybook) {
-    return <Navigate to="/courses" />
-  }
+            { // Stryker disable next-line all : GET is the default
+                method: "GET", url: "/api/courses/get",
+                params: {
+                    id
+                },
+            },
+    []
+        );
 
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Course Information</h1>
-        {
-          course && <CoursesForm initialContents={course}/>
-        }
-        <p>This is the place to upload student roster, add student or staff, and to show course details</p>
+        {course && (
+          <>
+            <CoursesTable initialContents={course} currentUser={currentUser}/>
+            <div>
+              {/* Course Roster Upload Link */}
+              <p>
+                <strong>Course Roster Upload:</strong>{" "}
+                <a href={`/courses/${id}/roster-upload`}>Upload Roster</a>
+              </p>
+              {/* Staff Roster */}
+              <p>
+                <strong>Staff Roster:</strong>{" "}
+                <a href={`/courses/${id}/staff-roster`}>View Staff</a>
+              </p>
+              {/* Student Roster */}
+              <p>
+                <strong>Student Roster:</strong>{" "}
+                <a href={`/courses/${id}/student-roster`}>View Students</a>
+              </p>
+            </div>
+          </>
+        )}
       </div>
     </BasicLayout>
-  )
+  );
 }

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -1,3 +1,4 @@
+
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
@@ -9,12 +10,10 @@ export default function CoursesShowPage() {
     let { id } = useParams();
     const { data: currentUser } = useCurrentUser();
 
-    const { data: course, error: _error, status: _status } =
+    const { data: courses, error: _error, status: _status } =
         useBackend(
-            // Stryker disable next-line all : don't test internal caching of React Query
-            [`/api/courses/show?id=${id}`],
-
-            { // Stryker disable next-line all : GET is the default
+            [`/api/courses?id=${id}`],
+            {
                 method: "GET", url: "/api/courses/get",
                 params: {
                     id
@@ -22,16 +21,20 @@ export default function CoursesShowPage() {
             },
     []
         );
+        let checkLength = [];
+        if (courses && courses.length !== 0) {
+            checkLength = [courses];
+        } else if (courses) {
+            checkLength = courses;
+        }
 
-  return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Course Information</h1>
-        {course && (
-          <>
-            <CoursesTable initialContents={course} currentUser={currentUser}/>
-            <div>
-              {/* Course Roster Upload Link */}
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Individual Course Details</h1>
+                <CoursesTable courses={checkLength} currentUser={currentUser} />
+                <br></br>
+                {/* Course Roster Upload Link */}
               <p>
                 <strong>Course Roster Upload:</strong>{" "}
                 <a href={`/courses/${id}/roster-upload`}>Upload Roster</a>
@@ -47,9 +50,6 @@ export default function CoursesShowPage() {
                 <a href={`/courses/${id}/student-roster`}>View Students</a>
               </p>
             </div>
-          </>
-        )}
-      </div>
-    </BasicLayout>
-  );
+        </BasicLayout>
+    );
 }

--- a/frontend/src/stories/pages/CoursesShowPage.stories.js
+++ b/frontend/src/stories/pages/CoursesShowPage.stories.js
@@ -14,8 +14,44 @@ export default {
 
 const Template = () => <CoursesShowPage storybook={true}/>;
 
-export const Default = Template.bind({});
-Default.parameters = {
+export const Empty = Template.bind({});
+Empty.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/courses/all', (_req, res, ctx) => {
+            return res(ctx.json([]));
+        })/*,
+        rest.put('/api/courses', async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200),ctx.json({}));
+        })*/,
+    ],
+}
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/courses/all', (_req, res, ctx) => {
+            return res(ctx.json(coursesFixtures.threeCourses));
+        }),
+    ],
+}
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
     msw: [
         rest.get('/api/currentUser', (_req, res, ctx) => {
             return res( ctx.json(apiCurrentUserFixtures.adminUser));
@@ -23,12 +59,11 @@ Default.parameters = {
         rest.get('/api/systemInfo', (_req, res, ctx) => {
             return res(ctx.json(systemInfoFixtures.showingNeither));
         }),
-        rest.get('/api/courses', (_req, res, ctx) => {
-            return res(ctx.json(coursesFixtures.threeCourses[0]));
+        rest.get('/api/ucsbdates/all', (_req, res, ctx) => {
+            return res(ctx.json(coursesFixtures.threeCourses));
         }),
-        rest.put('/api/courses', async (req, res, ctx) => {
-            var reqBody = await req.text();
-            window.alert("PUT: " + req.url + " and body: " + reqBody);
+        rest.delete('/api/ucsbdates', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
             return res(ctx.status(200),ctx.json({}));
         }),
     ],

--- a/frontend/src/stories/pages/CoursesShowPage.stories.js
+++ b/frontend/src/stories/pages/CoursesShowPage.stories.js
@@ -23,7 +23,7 @@ Empty.parameters = {
         rest.get('/api/systemInfo', (_req, res, ctx) => {
             return res(ctx.json(systemInfoFixtures.showingNeither));
         }),
-        rest.get('/api/courses/all', (_req, res, ctx) => {
+        rest.get('/api/courses/get', (_req, res, ctx) => {
             return res(ctx.json([]));
         })/*,
         rest.put('/api/courses', async (req, res, ctx) => {
@@ -33,9 +33,9 @@ Empty.parameters = {
         })*/,
     ],
 }
-export const ThreeItemsOrdinaryUser = Template.bind({});
+export const OrdinaryUser = Template.bind({});
 
-ThreeItemsOrdinaryUser.parameters = {
+OrdinaryUser.parameters = {
     msw: [
         rest.get('/api/currentUser', (_req, res, ctx) => {
             return res( ctx.json(apiCurrentUserFixtures.userOnly));
@@ -43,15 +43,15 @@ ThreeItemsOrdinaryUser.parameters = {
         rest.get('/api/systemInfo', (_req, res, ctx) => {
             return res(ctx.json(systemInfoFixtures.showingNeither));
         }),
-        rest.get('/api/courses/all', (_req, res, ctx) => {
-            return res(ctx.json(coursesFixtures.threeCourses));
+        rest.get('/api/courses/get', (_req, res, ctx) => {
+            return res(ctx.json(coursesFixtures.oneCourse));
         }),
     ],
 }
 
-export const ThreeItemsAdminUser = Template.bind({});
+export const AdminUser = Template.bind({});
 
-ThreeItemsAdminUser.parameters = {
+AdminUser.parameters = {
     msw: [
         rest.get('/api/currentUser', (_req, res, ctx) => {
             return res( ctx.json(apiCurrentUserFixtures.adminUser));
@@ -59,15 +59,24 @@ ThreeItemsAdminUser.parameters = {
         rest.get('/api/systemInfo', (_req, res, ctx) => {
             return res(ctx.json(systemInfoFixtures.showingNeither));
         }),
-        rest.get('/api/ucsbdates/all', (_req, res, ctx) => {
-            return res(ctx.json(coursesFixtures.threeCourses));
-        }),
-        rest.delete('/api/ucsbdates', (req, res, ctx) => {
-            window.alert("DELETE: " + JSON.stringify(req.url));
-            return res(ctx.status(200),ctx.json({}));
-        }),
+        rest.get('/api/courses/get', (_req, res, ctx) => {
+            return res(ctx.json(coursesFixtures.oneCourse));
+        })
     ],
 }
 
+export const InstructorUser = Template.bind({});
 
-
+InstructorUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.instructorUser));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/courses/get', (_req, res, ctx) => {
+            return res(ctx.json(coursesFixtures.oneCourse));
+        })
+    ],
+}

--- a/frontend/src/stories/pages/CoursesShowPage.stories.js
+++ b/frontend/src/stories/pages/CoursesShowPage.stories.js
@@ -1,0 +1,38 @@
+
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { coursesFixtures } from 'fixtures/coursesFixtures';
+import { rest } from "msw";
+
+import CoursesShowPage from 'main/pages/CoursesShowPage';
+
+export default {
+    title: 'pages/CoursesShowPage',
+    component: CoursesShowPage
+};
+
+const Template = () => <CoursesShowPage storybook={true}/>;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.adminUser));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/courses', (_req, res, ctx) => {
+            return res(ctx.json(coursesFixtures.threeCourses[0]));
+        }),
+        rest.put('/api/courses', async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}
+
+
+

--- a/frontend/src/tests/components/Courses/CoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/CoursesTable.test.js
@@ -57,6 +57,9 @@ describe("UserTable tests", () => {
     const deleteButton = screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`);
     expect(deleteButton).not.toBeInTheDocument();
 
+    const showButton = screen.queryByTestId(`${testId}-cell-row-0-col-Show-button`);
+    expect(showButton).not.toBeInTheDocument();
+
     const totalCoursesElement = screen.getByText("Total Courses: 3"); // Assuming there are 3 courses in the fixture
     expect(totalCoursesElement).toBeInTheDocument();
 
@@ -138,6 +141,10 @@ describe("UserTable tests", () => {
     expect(deleteButton).toBeInTheDocument();
     expect(deleteButton).toHaveClass("btn-danger");
 
+    const showButton = screen.getByTestId(`${testId}-cell-row-0-col-Show-button`);
+    expect(showButton).toBeInTheDocument();
+    expect(showButton).toHaveClass("btn-primary");
+
     const totalCoursesElement = screen.getByText("Total Courses: 3"); // Assuming there are 3 courses in the fixture
     expect(totalCoursesElement).toBeInTheDocument();
   });
@@ -187,6 +194,10 @@ describe("UserTable tests", () => {
     expect(deleteButton).toBeInTheDocument();
     expect(deleteButton).toHaveClass("btn-danger");
 
+    const showButton = screen.getByTestId(`${testId}-cell-row-0-col-Show-button`);
+    expect(showButton).toBeInTheDocument();
+    expect(showButton).toHaveClass("btn-primary");
+
   });
 
   test("Join button navigates to the join page for a user", async () => {
@@ -204,7 +215,7 @@ describe("UserTable tests", () => {
     );
 
     await waitFor(() => { expect(screen.getByTestId(`CoursesTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
-   const joinButton = screen.getByTestId(`CoursesTable-cell-row-0-col-Join-button`);
+    const joinButton = screen.getByTestId(`CoursesTable-cell-row-0-col-Join-button`);
     expect(joinButton).toBeInTheDocument();
 
     fireEvent.click(joinButton);
@@ -289,6 +300,30 @@ describe("UserTable tests", () => {
     expect(deleteButton).toBeInTheDocument();
 
     fireEvent.click(deleteButton);
+
+    const totalCoursesElement = screen.getByText("Total Courses: 3"); // Assuming there are 3 courses in the fixture
+    expect(totalCoursesElement).toBeInTheDocument();
+  });
+
+  test("Show button shows individual course information", async () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+            <CoursesTable courses={coursesFixtures.threeCourses} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    await waitFor(() => { expect(screen.getByTestId(`CoursesTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+    const showButton = screen.getByTestId(`CoursesTable-cell-row-0-col-Show-button`);
+    expect(showButton).toBeInTheDocument();
+
+    fireEvent.click(showButton);
 
     const totalCoursesElement = screen.getByText("Total Courses: 3"); // Assuming there are 3 courses in the fixture
     expect(totalCoursesElement).toBeInTheDocument();

--- a/frontend/src/tests/components/Courses/CoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/CoursesTable.test.js
@@ -327,6 +327,10 @@ describe("UserTable tests", () => {
 
     const totalCoursesElement = screen.getByText("Total Courses: 3"); // Assuming there are 3 courses in the fixture
     expect(totalCoursesElement).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockedNavigate).toHaveBeenCalledWith('/courses/show/1');
+    });
   });
 
 });

--- a/frontend/src/tests/components/Courses/ShowTable.test.js
+++ b/frontend/src/tests/components/Courses/ShowTable.test.js
@@ -1,0 +1,228 @@
+import ShowTable from "main/components/Courses/ShowTable"
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { coursesFixtures } from "fixtures/coursesFixtures";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("UserTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("Has the expected column headers and content for ordinary user", () => {
+
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ShowTable courses={coursesFixtures.threeCourses} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ["id", "Name", "School", "Term", "StartDate", "EndDate", "GitHub Org"];
+    const expectedFields = ["id", "name", "school", "term", "startDate", "endDate", "githubOrg"];
+    const testId = "ShowTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+
+
+    const editButton = screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).not.toBeInTheDocument();
+
+    const totalCoursesElement = screen.getByText("Total Courses: 3"); // Assuming there are 3 courses in the fixture
+    expect(totalCoursesElement).toBeInTheDocument();
+
+  });
+
+
+  
+  test("renders empty table correctly", () => {
+
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+    const expectedHeaders = ["id", "Name", "School", "Term", "StartDate", "EndDate", "GitHub Org"];
+    const expectedFields = ["id", "name", "school", "term", "startDate", "endDate", "githubOrg"];
+    const testId = "ShowTable";
+    
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ShowTable courses={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+
+    const totalCoursesElement = screen.getByText("Total Courses: 0"); // Since the table is empty
+    expect(totalCoursesElement).toBeInTheDocument();
+  });
+
+
+  test("Has the expected colum headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+            <ShowTable courses={coursesFixtures.threeCourses} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ["id", "Name", "School", "Term", "StartDate", "EndDate", "GitHub Org"];
+    const expectedFields = ["id", "name", "school", "term", "startDate", "endDate", "githubOrg"];
+    const testId = "ShowTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const totalCoursesElement = screen.getByText("Total Courses: 3"); // Assuming there are 3 courses in the fixture
+    expect(totalCoursesElement).toBeInTheDocument();
+  });
+
+  test("Has the expected colum headers and content for instructorUser", () => {
+
+    const currentUser = currentUserFixtures.instructorUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+            <ShowTable courses={coursesFixtures.threeCourses} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ["id", "Name", "School", "Term", "StartDate", "EndDate", "GitHub Org"];
+    const expectedFields = ["id", "name", "school", "term", "startDate", "endDate", "githubOrg"];
+    const testId = "ShowTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+
+    const staffButton = screen.getByTestId(`${testId}-cell-row-0-col-Staff-button`);
+    expect(staffButton).toBeInTheDocument();
+    expect(staffButton).toHaveClass("btn-primary");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+  });
+
+
+  test("Staff button navigates to the staff page for admin user", async () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+            <ShowTable courses={coursesFixtures.threeCourses} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    await waitFor(() => { expect(screen.getByTestId(`ShowTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+
+
+    const staffButton = screen.getByTestId(`ShowTable-cell-row-0-col-Staff-button`);
+    expect(staffButton).toBeInTheDocument();
+
+    fireEvent.click(staffButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/courses/1/staff'));
+
+  });
+
+
+  test("Edit button navigates to the edit page for admin user", async () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+            <ShowTable courses={coursesFixtures.threeCourses} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    await waitFor(() => { expect(screen.getByTestId(`ShowTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+    const editButton = screen.getByTestId(`ShowTable-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+
+    fireEvent.click(editButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/courses/edit/1'));
+    
+    const totalCoursesElement = screen.getByText("Total Courses: 3"); // Assuming there are 3 courses in the fixture
+    expect(totalCoursesElement).toBeInTheDocument();
+    
+  });
+});

--- a/frontend/src/tests/pages/CoursesShowPage.test.js
+++ b/frontend/src/tests/pages/CoursesShowPage.test.js
@@ -37,7 +37,7 @@ describe("CoursesShowPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
 
-    const testId = "CoursesTable";
+    const testId = "ShowTable";
 
     const setupAdminUser = () => {
         axiosMock.reset();
@@ -109,39 +109,6 @@ describe("CoursesShowPage tests", () => {
 
     test("renders empty table when backend unavailable, instructor", async () => {
         await renderAndAssertEmptyTable(setupInstructorUser);
-    });
-
-    const testDeleteCourse = async (userSetup) => {
-        userSetup();
-        const queryClient = new QueryClient();
-        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
-        axiosMock.onDelete("/api/courses/delete").reply(200, "Course with id 1 was deleted");
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <CoursesShowPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
-        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-
-        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-        expect(deleteButton).toBeInTheDocument();
-
-        fireEvent.click(deleteButton);
-
-        await waitFor(() => { expect(mockToast).toBeCalledWith("Course with id 1 was deleted") });
-    };
-
-    test("what happens when you click delete, admin", async () => {
-        await testDeleteCourse(setupAdminUser);
-    });
-
-    test("what happens when you click delete, instructor", async () => {
-        await testDeleteCourse(setupInstructorUser);
     });
 
     test("tests buttons for editing do not show up for user", async () => {

--- a/frontend/src/tests/pages/CoursesShowPage.test.js
+++ b/frontend/src/tests/pages/CoursesShowPage.test.js
@@ -131,28 +131,6 @@ describe("CoursesShowPage tests", () => {
         expect(deleteButton).not.toBeInTheDocument();
     });
 
-    test("check that the course links are correct", async () => {
-        setupAdminUser();
-        const queryClient = new QueryClient();
-        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
-    
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <CoursesShowPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-    
-        await waitFor(() => {
-            expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument();
-        });
-    
-        expect(screen.getByRole('link', { name: /Upload Roster/i })).toHaveAttribute('href', '/courses/17/roster-upload');
-        expect(screen.getByRole('link', { name: /View Staff/i })).toHaveAttribute('href', '/courses/17/staff-roster');
-        expect(screen.getByRole('link', { name: /View Students/i })).toHaveAttribute('href', '/courses/17/student-roster');
-    });
-
     test("check if correct API URL is called", async () => {
         setupAdminUser();
         const queryClient = new QueryClient();

--- a/frontend/src/tests/pages/CoursesShowPage.test.js
+++ b/frontend/src/tests/pages/CoursesShowPage.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import CoursesShowPage from "main/pages/CoursesShowPage";

--- a/frontend/src/tests/pages/CoursesShowPage.test.js
+++ b/frontend/src/tests/pages/CoursesShowPage.test.js
@@ -98,13 +98,13 @@ describe("CoursesShowPage tests", () => {
     });
 
     test("renders empty table when backend unavailable, admin", async () => {
-
+     
         setupAdminUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).timeout();
         const restoreConsole = mockConsole();
 
-
+        
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -113,7 +113,7 @@ describe("CoursesShowPage tests", () => {
             </QueryClientProvider>
         );
 
-
+       
         await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
 
         restoreConsole();
@@ -122,13 +122,13 @@ describe("CoursesShowPage tests", () => {
     });
 
     test("renders empty table when backend unavailable, instructor", async () => {
-
+       
         setupInstructorUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).timeout();
         const restoreConsole = mockConsole();
 
-
+       
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -137,7 +137,7 @@ describe("CoursesShowPage tests", () => {
             </QueryClientProvider>
         );
 
-
+       
         await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
 
         restoreConsole();
@@ -146,13 +146,13 @@ describe("CoursesShowPage tests", () => {
     });
 
     test("what happens when you click delete, admin", async () => {
-
+        
         setupAdminUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
         axiosMock.onDelete("/api/courses/delete").reply(200, "Course with id 1 was deleted");
 
-
+        
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -161,7 +161,7 @@ describe("CoursesShowPage tests", () => {
             </QueryClientProvider>
         );
 
-
+       
         await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
 
         expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
@@ -169,22 +169,22 @@ describe("CoursesShowPage tests", () => {
         const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
         expect(deleteButton).toBeInTheDocument();
 
-
+       
         fireEvent.click(deleteButton);
 
-
+       
         await waitFor(() => { expect(mockToast).toBeCalledWith("Course with id 1 was deleted") });
 
     });
 
     test("what happens when you click delete, instructor", async () => {
-
+        
         setupInstructorUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
         axiosMock.onDelete("/api/courses/delete").reply(200, "Course with id 1 was deleted");
 
-
+        
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -193,7 +193,7 @@ describe("CoursesShowPage tests", () => {
             </QueryClientProvider>
         );
 
-
+       
         await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
 
         expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
@@ -201,21 +201,21 @@ describe("CoursesShowPage tests", () => {
         const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
         expect(deleteButton).toBeInTheDocument();
 
-
+        
         fireEvent.click(deleteButton);
 
-
+        
         await waitFor(() => { expect(mockToast).toBeCalledWith("Course with id 1 was deleted") });
 
     });
 
     test("tests buttons for editing do not show up for user", async () => {
-
+        
         setupUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
 
-
+        
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -224,7 +224,7 @@ describe("CoursesShowPage tests", () => {
             </QueryClientProvider>
         );
 
-
+       
         await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
 
         expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
@@ -278,7 +278,7 @@ describe("CoursesShowPage tests", () => {
         setupAdminUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
-
+    
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -286,14 +286,14 @@ describe("CoursesShowPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
-
+    
         await waitFor(() => {
             expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument();
         });
-
-        expect(screen.getByText("Upload Roster").closest('a')).toHaveAttribute('href', '/courses/17/roster-upload');
-        expect(screen.getByText("View Staff").closest('a')).toHaveAttribute('href', '/courses/17/staff-roster');
-        expect(screen.getByText("View Students").closest('a')).toHaveAttribute('href', '/courses/17/student-roster');
+    
+        expect(screen.getByRole('link', { name: /Upload Roster/i })).toHaveAttribute('href', '/courses/17/roster-upload');
+        expect(screen.getByRole('link', { name: /View Staff/i })).toHaveAttribute('href', '/courses/17/staff-roster');
+        expect(screen.getByRole('link', { name: /View Students/i })).toHaveAttribute('href', '/courses/17/student-roster');
     });
 
 });

--- a/frontend/src/tests/pages/CoursesShowPage.test.js
+++ b/frontend/src/tests/pages/CoursesShowPage.test.js
@@ -201,6 +201,8 @@ describe("CoursesShowPage tests", () => {
 
         await waitFor(() => {
             expect(axiosMock.history.get.length).toBe(3);
+        });
+        await waitFor(() => {
             expect(axiosMock.history.get[0].url).toBe("/api/currentUser");
         });
     });
@@ -220,6 +222,8 @@ describe("CoursesShowPage tests", () => {
 
         await waitFor(() => {
             expect(axiosMock.history.get.length).toBe(3);
+        });
+        await waitFor(() => {
             expect(axiosMock.history.get[0].method).toBe("get");
         });
     });
@@ -244,7 +248,7 @@ describe("CoursesShowPage tests", () => {
     test("throw a falsy value to courses?", async () => {
         setupAdminUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, 0);
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, []);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -254,6 +258,6 @@ describe("CoursesShowPage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument();
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument();
     });
 });

--- a/frontend/src/tests/pages/CoursesShowPage.test.js
+++ b/frontend/src/tests/pages/CoursesShowPage.test.js
@@ -1,0 +1,249 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import CoursesShowPage from "main/pages/CoursesShowPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { coursesFixtures } from "fixtures/coursesFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("CoursesShowPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "CoursesTable";
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupInstructorUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.instructorUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    }
+
+    const setupUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    }
+
+
+
+    test("renders course correctly for admin", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+    });
+
+    test("renders course correctly for instructor", async () => {
+        setupInstructorUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+    });
+
+    test("renders empty table when backend unavailable, admin", async () => {
+
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).timeout();
+        const restoreConsole = mockConsole();
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        restoreConsole();
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    test("renders empty table when backend unavailable, instructor", async () => {
+
+        setupInstructorUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).timeout();
+        const restoreConsole = mockConsole();
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        restoreConsole();
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    test("what happens when you click delete, admin", async () => {
+
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+        axiosMock.onDelete("/api/courses/delete").reply(200, "Course with id 1 was deleted");
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+
+        fireEvent.click(deleteButton);
+
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Course with id 1 was deleted") });
+
+    });
+
+    test("what happens when you click delete, instructor", async () => {
+
+        setupInstructorUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+        axiosMock.onDelete("/api/courses/delete").reply(200, "Course with id 1 was deleted");
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+
+        fireEvent.click(deleteButton);
+
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Course with id 1 was deleted") });
+
+    });
+
+    test("tests buttons for editing do not show up for user", async () => {
+
+        setupUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+        const deleteButton = screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).not.toBeInTheDocument();
+
+    });
+
+    test("checkLength should contain one element if courses is not empty", () => {
+        const courses = [{ id: 1, name: "Test Course" }];
+        let checkLength = [];
+        if (courses && courses.length !== 0) {
+            checkLength = [courses];
+        } else if (courses) {
+            checkLength = courses;
+        }
+
+        expect(checkLength).toEqual([courses]);
+    });
+
+});

--- a/frontend/src/tests/pages/CoursesShowPage.test.js
+++ b/frontend/src/tests/pages/CoursesShowPage.test.js
@@ -248,7 +248,7 @@ describe("CoursesShowPage tests", () => {
     test("throw a falsy value to courses?", async () => {
         setupAdminUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, []);
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, 0);
 
         render(
             <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/pages/CoursesShowPage.test.js
+++ b/frontend/src/tests/pages/CoursesShowPage.test.js
@@ -239,11 +239,61 @@ describe("CoursesShowPage tests", () => {
         let checkLength = [];
         if (courses && courses.length !== 0) {
             checkLength = [courses];
-        } else if (courses) {
+        } else {
             checkLength = courses;
         }
 
         expect(checkLength).toEqual([courses]);
+    });
+
+    test("checkLength should contain courses if courses exists but is empty", () => {
+        const courses = [];
+        let checkLength = courses;
+        if (courses && courses.length !== 0) {
+            checkLength = [courses];
+        } else {
+            checkLength = courses;
+        }
+
+        expect(checkLength).toEqual(courses);
+    });
+
+    test("throw a falsy value to courses?", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, 0);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    test("check that the course links are correct", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument();
+        });
+
+        expect(screen.getByText("Upload Roster").closest('a')).toHaveAttribute('href', '/courses/17/roster-upload');
+        expect(screen.getByText("View Staff").closest('a')).toHaveAttribute('href', '/courses/17/staff-roster');
+        expect(screen.getByText("View Students").closest('a')).toHaveAttribute('href', '/courses/17/student-roster');
     });
 
 });


### PR DESCRIPTION
In this pull request, I implemented a course show page that will allow admins and instructors to have a look at individual course information along with its corresponding tests and storybooks. I created a show button which will link you to that page. There is also a short description to let the admins/instructors know what to do on this page, and links created to add students, staff, or class rosters though those are not linked to anything yet as it is for future implementation. 

Dokku deployment:
https://proj1-peak1260-dev.dokku-09.cs.ucsb.edu/

Closes #10.
