### PR TITLE
rt.z: A commit to get you to full test coverage

### DIFF
--- a/frontend/src/tests/pages/CoursesShowPage.test.js
+++ b/frontend/src/tests/pages/CoursesShowPage.test.js
@@ -246,4 +246,31 @@ describe("CoursesShowPage tests", () => {
         expect(checkLength).toEqual([courses]);
     });
 
+    test("checkLength should contain courses if courses exists but is empty", () => {
+        const courses = [];
+        let checkLength = courses;
+        if (courses && courses.length !== 0) {
+            checkLength = [courses];
+        } else if (courses) {
+            checkLength = courses;
+        }
+
+        expect(checkLength).toEqual(courses);
+    });
+
+    test("throw a falsy value to courses?", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, 0);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
In `CoursesShowPage.js` there exists these lines.
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-1/assets/50055753/bfcfe76f-142d-4c55-a8de-90c83750c5d2)

Because we didn't have any test cases where both `courses && courses.length !== 0` and `courses` are false, that is considered a branch we did not cover in our test cases. Thus, by adding a test case where we pass a falsy value to `courses`, we should have full test coverage now.
