### PR TITLE
Removed TermError from the UX

### DIFF
--- a/frontend/src/main/components/School/SchoolForm.js
+++ b/frontend/src/main/components/School/SchoolForm.js
@@ -91,24 +91,6 @@ function SchoolForm({ initialContents, submitAction, buttonLabel = "Create" }) {
 
             <Row>
                 <Col>
-                    <Form.Group className="mb-3" >
-                        <Form.Label htmlFor="termError">Term Error</Form.Label>
-                        <Form.Control
-                            data-testid="SchoolForm-termError"
-                            id="termError"
-                            type="text"
-                            isInvalid={Boolean(errors.termError)}
-                            {...register("termError", { required: true})}
-                        />
-                        <Form.Control.Feedback type="invalid">
-                            {errors.termError && 'Term Error is required.'}
-                        </Form.Control.Feedback>
-                    </Form.Group>
-                </Col>
-            </Row>
-
-            <Row>
-                <Col>
                     <Button
                         type="submit"
                         data-testid="SchoolForm-submit"

--- a/frontend/src/main/components/School/SchoolTable.js
+++ b/frontend/src/main/components/School/SchoolTable.js
@@ -45,10 +45,6 @@ import React from "react";
              Header: 'TermDescription',
              accessor: 'termDescription',
          },
-         {
-             Header: 'TermError',
-             accessor: 'termError',
-         },
      ];
 
      if (hasRole(currentUser, "ROLE_ADMIN")) {

--- a/frontend/src/tests/components/School/SchoolForm.test.js
+++ b/frontend/src/tests/components/School/SchoolForm.test.js
@@ -64,7 +64,6 @@ describe("SchoolForm tests", () => {
         expect(screen.getByText(/Name is required./)).toBeInTheDocument();
         expect(screen.getByText(/Term Regex is required./)).toBeInTheDocument();
         expect(screen.getByText(/Term Description is required./)).toBeInTheDocument();
-        // expect(screen.getByText(/Term Error is required./)).toBeInTheDocument();
     });
 
     test("No Error messsages on good input", async () => {
@@ -80,14 +79,12 @@ describe("SchoolForm tests", () => {
         const nameField = screen.getByTestId("SchoolForm-name");
         const termRegexField = screen.getByTestId("SchoolForm-termRegex");
         const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
-        // const termErrorField = screen.getByTestId("SchoolForm-termError");
         const submitButton = screen.getByTestId("SchoolForm-submit");
 
         fireEvent.change(abbrevField, { target: { value: 'ucsb' } });
         fireEvent.change(nameField, { target: { value: 'UC Santa Barbara' } });
         fireEvent.change(termRegexField, { target: { value: '[WSMF]\\d\\d' } });
         fireEvent.change(termDescriptionField, { target: { value: 'Enter quarter, e.g. F23, W24, S24, M24' } });
-        // fireEvent.change(termErrorField, { target: { value: 'Quarter must be entered in the correct format' } });
         fireEvent.click(submitButton);
 
         await screen.findByTestId(/SchoolForm-abbrev/);
@@ -96,7 +93,6 @@ describe("SchoolForm tests", () => {
         expect(screen.queryByText(/Name is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Term Regex is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Term Description is required./)).not.toBeInTheDocument();
-        // expect(screen.queryByText(/Term Error is required./)).not.toBeInTheDocument();
     });
 
     test("that navigate(-1) is called when Cancel is clicked", async () => {

--- a/frontend/src/tests/components/School/SchoolForm.test.js
+++ b/frontend/src/tests/components/School/SchoolForm.test.js
@@ -64,7 +64,7 @@ describe("SchoolForm tests", () => {
         expect(screen.getByText(/Name is required./)).toBeInTheDocument();
         expect(screen.getByText(/Term Regex is required./)).toBeInTheDocument();
         expect(screen.getByText(/Term Description is required./)).toBeInTheDocument();
-        expect(screen.getByText(/Term Error is required./)).toBeInTheDocument();
+        // expect(screen.getByText(/Term Error is required./)).toBeInTheDocument();
     });
 
     test("No Error messsages on good input", async () => {
@@ -80,14 +80,14 @@ describe("SchoolForm tests", () => {
         const nameField = screen.getByTestId("SchoolForm-name");
         const termRegexField = screen.getByTestId("SchoolForm-termRegex");
         const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
-        const termErrorField = screen.getByTestId("SchoolForm-termError");
+        // const termErrorField = screen.getByTestId("SchoolForm-termError");
         const submitButton = screen.getByTestId("SchoolForm-submit");
 
         fireEvent.change(abbrevField, { target: { value: 'ucsb' } });
         fireEvent.change(nameField, { target: { value: 'UC Santa Barbara' } });
         fireEvent.change(termRegexField, { target: { value: '[WSMF]\\d\\d' } });
         fireEvent.change(termDescriptionField, { target: { value: 'Enter quarter, e.g. F23, W24, S24, M24' } });
-        fireEvent.change(termErrorField, { target: { value: 'Quarter must be entered in the correct format' } });
+        // fireEvent.change(termErrorField, { target: { value: 'Quarter must be entered in the correct format' } });
         fireEvent.click(submitButton);
 
         await screen.findByTestId(/SchoolForm-abbrev/);
@@ -96,7 +96,7 @@ describe("SchoolForm tests", () => {
         expect(screen.queryByText(/Name is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Term Regex is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Term Description is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/Term Error is required./)).not.toBeInTheDocument();
+        // expect(screen.queryByText(/Term Error is required./)).not.toBeInTheDocument();
     });
 
     test("that navigate(-1) is called when Cancel is clicked", async () => {

--- a/frontend/src/tests/components/School/SchoolTable.test.js
+++ b/frontend/src/tests/components/School/SchoolTable.test.js
@@ -29,8 +29,8 @@ describe("UserTable tests", () => {
 
     );
 
-    const expectedHeaders = ["Abbrev", "Name", "TermRegex", "TermDescription", "TermError"];
-    const expectedFields = ["abbrev", "name", "termRegex", "termDescription", "termError"];
+    const expectedHeaders = ["Abbrev", "Name", "TermRegex", "TermDescription"];
+    const expectedFields = ["abbrev", "name", "termRegex", "termDescription"];
     const testId = "SchoolTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -60,8 +60,8 @@ describe("UserTable tests", () => {
     // arrange
     const currentUser = currentUserFixtures.adminUser;
 
-    const expectedHeaders = ["Abbrev", "Name", "TermRegex", "TermDescription", "TermError"];
-    const expectedFields = ["abbrev", "name", "termRegex", "termDescription", "termError"];
+    const expectedHeaders = ["Abbrev", "Name", "TermRegex", "TermDescription"];
+    const expectedFields = ["abbrev", "name", "termRegex", "termDescription"];
     const testId = "SchoolTable";
 
     // act
@@ -99,8 +99,8 @@ describe("UserTable tests", () => {
 
     );
 
-    const expectedHeaders = ["Abbrev", "Name", "TermRegex", "TermDescription", "TermError"];
-    const expectedFields = ["abbrev", "name", "termRegex", "termDescription", "termError"];
+    const expectedHeaders = ["Abbrev", "Name", "TermRegex", "TermDescription"];
+    const expectedFields = ["abbrev", "name", "termRegex", "termDescription"];
     const testId = "SchoolTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/frontend/src/tests/pages/SchoolCreatePage.test.js
+++ b/frontend/src/tests/pages/SchoolCreatePage.test.js
@@ -62,7 +62,6 @@ describe("SchoolCreatePage tests", () => {
             name: "name-1",
             termRegex: "[WSMF]\\d\\d",
             termDescription: "F23",
-            // termError: "error-1"
         };
 
         axiosMock.onPost("/api/schools/post").reply(200, school);
@@ -82,7 +81,6 @@ describe("SchoolCreatePage tests", () => {
         const nameField = screen.getByTestId("SchoolForm-name");
         const termRegexField = screen.getByTestId("SchoolForm-termRegex");
         const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
-        // const termErrorField = screen.getByTestId("SchoolForm-termError");
         const submitButton = screen.getByTestId("SchoolForm-submit");
 
        
@@ -90,7 +88,6 @@ describe("SchoolCreatePage tests", () => {
         fireEvent.change(nameField, { target: { value: 'name-1' } });
         fireEvent.change(termRegexField, { target: { value: '[WSMF]\\d\\d' } });
         fireEvent.change(termDescriptionField, { target: { value: 'F23' } });
-        // fireEvent.change(termErrorField, { target: { value: 'error-1' } });
       
 
         fireEvent.click(submitButton);
@@ -103,7 +100,6 @@ describe("SchoolCreatePage tests", () => {
                 "name": "name-1",
                 "termRegex": "[WSMF]\\d\\d",
                 "termDescription": "F23",
-                // "termError": "error-1"
         }));
 
         expect(mockToast).toBeCalledWith("New school created - id: abb");

--- a/frontend/src/tests/pages/SchoolCreatePage.test.js
+++ b/frontend/src/tests/pages/SchoolCreatePage.test.js
@@ -62,7 +62,7 @@ describe("SchoolCreatePage tests", () => {
             name: "name-1",
             termRegex: "[WSMF]\\d\\d",
             termDescription: "F23",
-            termError: "error-1"
+            // termError: "error-1"
         };
 
         axiosMock.onPost("/api/schools/post").reply(200, school);
@@ -82,7 +82,7 @@ describe("SchoolCreatePage tests", () => {
         const nameField = screen.getByTestId("SchoolForm-name");
         const termRegexField = screen.getByTestId("SchoolForm-termRegex");
         const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
-        const termErrorField = screen.getByTestId("SchoolForm-termError");
+        // const termErrorField = screen.getByTestId("SchoolForm-termError");
         const submitButton = screen.getByTestId("SchoolForm-submit");
 
        
@@ -90,7 +90,7 @@ describe("SchoolCreatePage tests", () => {
         fireEvent.change(nameField, { target: { value: 'name-1' } });
         fireEvent.change(termRegexField, { target: { value: '[WSMF]\\d\\d' } });
         fireEvent.change(termDescriptionField, { target: { value: 'F23' } });
-        fireEvent.change(termErrorField, { target: { value: 'error-1' } });
+        // fireEvent.change(termErrorField, { target: { value: 'error-1' } });
       
 
         fireEvent.click(submitButton);
@@ -103,7 +103,7 @@ describe("SchoolCreatePage tests", () => {
                 "name": "name-1",
                 "termRegex": "[WSMF]\\d\\d",
                 "termDescription": "F23",
-                "termError": "error-1"
+                // "termError": "error-1"
         }));
 
         expect(mockToast).toBeCalledWith("New school created - id: abb");

--- a/frontend/src/tests/pages/SchoolEditPage.test.js
+++ b/frontend/src/tests/pages/SchoolEditPage.test.js
@@ -107,7 +107,6 @@ describe("SchoolEditPage tests", () => {
             const nameField = screen.getByTestId("SchoolForm-name");
             const termRegexField = screen.getByTestId("SchoolForm-termRegex");
             const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
-            // const termErrorField = screen.getByTestId("SchoolForm-termError");
             const submitButton = screen.getByTestId("SchoolForm-submit");
 
             expect(abbrevField).toBeInTheDocument();
@@ -118,15 +117,12 @@ describe("SchoolEditPage tests", () => {
             expect(termRegexField).toHaveValue("reg-17");
             expect(termDescriptionField).toBeInTheDocument();
             expect(termDescriptionField).toHaveValue("description-17");
-            // expect(termErrorField).toBeInTheDocument();
-            // expect(termErrorField).toHaveValue("error-17");
 
             expect(submitButton).toHaveTextContent("Update");
 
             fireEvent.change(nameField, { target: { value: 'new-name-17' } });
             fireEvent.change(termRegexField, { target: { value: 'new-reg-17' } });
             fireEvent.change(termDescriptionField, { target: { value: 'new-description-17' } });
-            // fireEvent.change(termErrorField, { target: { value: 'new-error-17' } });
             fireEvent.click(submitButton);
 
             await waitFor(() => expect(mockToast).toBeCalled());
@@ -161,7 +157,6 @@ describe("SchoolEditPage tests", () => {
             const nameField = screen.getByTestId("SchoolForm-name");
             const termRegexField = screen.getByTestId("SchoolForm-termRegex");
             const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
-            // const termErrorField = screen.getByTestId("SchoolForm-termError");
             const submitButton = screen.getByTestId("SchoolForm-submit");
 
     
@@ -169,12 +164,10 @@ describe("SchoolEditPage tests", () => {
             expect(nameField).toHaveValue("name-17");
             expect(termRegexField).toHaveValue("reg-17");
             expect(termDescriptionField).toHaveValue("description-17");
-            // expect(termErrorField).toHaveValue("error-17");
 
             fireEvent.change(nameField, { target: { value: 'new-name-17' } });
             fireEvent.change(termRegexField, { target: { value: 'new-reg-17' } });
             fireEvent.change(termDescriptionField, { target: { value: 'new-description-17' } });
-            // fireEvent.change(termErrorField, { target: { value: 'new-error-17' } });
             fireEvent.click(submitButton);
 
             await waitFor(() => expect(mockToast).toBeCalled());

--- a/frontend/src/tests/pages/SchoolEditPage.test.js
+++ b/frontend/src/tests/pages/SchoolEditPage.test.js
@@ -107,7 +107,7 @@ describe("SchoolEditPage tests", () => {
             const nameField = screen.getByTestId("SchoolForm-name");
             const termRegexField = screen.getByTestId("SchoolForm-termRegex");
             const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
-            const termErrorField = screen.getByTestId("SchoolForm-termError");
+            // const termErrorField = screen.getByTestId("SchoolForm-termError");
             const submitButton = screen.getByTestId("SchoolForm-submit");
 
             expect(abbrevField).toBeInTheDocument();
@@ -118,15 +118,15 @@ describe("SchoolEditPage tests", () => {
             expect(termRegexField).toHaveValue("reg-17");
             expect(termDescriptionField).toBeInTheDocument();
             expect(termDescriptionField).toHaveValue("description-17");
-            expect(termErrorField).toBeInTheDocument();
-            expect(termErrorField).toHaveValue("error-17");
+            // expect(termErrorField).toBeInTheDocument();
+            // expect(termErrorField).toHaveValue("error-17");
 
             expect(submitButton).toHaveTextContent("Update");
 
             fireEvent.change(nameField, { target: { value: 'new-name-17' } });
             fireEvent.change(termRegexField, { target: { value: 'new-reg-17' } });
             fireEvent.change(termDescriptionField, { target: { value: 'new-description-17' } });
-            fireEvent.change(termErrorField, { target: { value: 'new-error-17' } });
+            // fireEvent.change(termErrorField, { target: { value: 'new-error-17' } });
             fireEvent.click(submitButton);
 
             await waitFor(() => expect(mockToast).toBeCalled());
@@ -140,7 +140,7 @@ describe("SchoolEditPage tests", () => {
                 name: "new-name-17",
                 termRegex: "new-reg-17",
                 termDescription: "new-description-17",
-                termError: "new-error-17" 
+                termError: "error-17" 
             })); 
 
 
@@ -161,7 +161,7 @@ describe("SchoolEditPage tests", () => {
             const nameField = screen.getByTestId("SchoolForm-name");
             const termRegexField = screen.getByTestId("SchoolForm-termRegex");
             const termDescriptionField = screen.getByTestId("SchoolForm-termDescription");
-            const termErrorField = screen.getByTestId("SchoolForm-termError");
+            // const termErrorField = screen.getByTestId("SchoolForm-termError");
             const submitButton = screen.getByTestId("SchoolForm-submit");
 
     
@@ -169,12 +169,12 @@ describe("SchoolEditPage tests", () => {
             expect(nameField).toHaveValue("name-17");
             expect(termRegexField).toHaveValue("reg-17");
             expect(termDescriptionField).toHaveValue("description-17");
-            expect(termErrorField).toHaveValue("error-17");
+            // expect(termErrorField).toHaveValue("error-17");
 
             fireEvent.change(nameField, { target: { value: 'new-name-17' } });
             fireEvent.change(termRegexField, { target: { value: 'new-reg-17' } });
             fireEvent.change(termDescriptionField, { target: { value: 'new-description-17' } });
-            fireEvent.change(termErrorField, { target: { value: 'new-error-17' } });
+            // fireEvent.change(termErrorField, { target: { value: 'new-error-17' } });
             fireEvent.click(submitButton);
 
             await waitFor(() => expect(mockToast).toBeCalled());


### PR DESCRIPTION
Removed TermError from the School form UX (from the form and table for course). You can check by going to Schools then go to either create school or edit school and also you can see from the table that the Term Error has been removed

http://organic-george2.dokku-09.cs.ucsb.edu/