### PR TITLE
fix the local host for spring 3

### DIFF
--- a/src/main/java/edu/ucsb/cs156/organic/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/FrontendProxyController.java
@@ -9,11 +9,13 @@ import org.springframework.web.client.ResourceAccessException;
 
 import java.net.ConnectException;
 
+
+
 @Profile("development")
 @RestController
 public class FrontendProxyController {
   @GetMapping({"/", "/{path:^(?!api|oauth2|swagger-ui).*}/**"})
-  public ResponseEntity<String> proxy(ProxyExchange<String> proxy) {
+  public ResponseEntity<?> proxy(ProxyExchange<byte []> proxy) {
     String path = proxy.path("/");
     try {
       return proxy.uri("http://localhost:3000/" + path).get();

--- a/src/test/java/edu/ucsb/cs156/organic/testconfig/TestConfig.java
+++ b/src/test/java/edu/ucsb/cs156/organic/testconfig/TestConfig.java
@@ -9,6 +9,7 @@ import edu.ucsb.cs156.organic.services.GrantedAuthoritiesService;
 import org.springframework.context.annotation.Import;
 
 @TestConfiguration
+
 @Import(SecurityConfig.class)
 public class TestConfig {
 


### PR DESCRIPTION
This is an issue with an older pull request that is already merged, because in the old pull request, thing works on the dokku. However, there is a decoding issue which causes that on local host when you click http://localhost:8080/ it shows you a blank page and gives you the decoding error. In order to fix this issue, I looked at the FrontendProxyController and noticed that it only takes the response from the frontend as string. So, I modified it to make sure it can take various kinds of responses and now the local host is working

dokku: http://proj-spring-daniel-dev.dokku-09.cs.ucsb.edu/

closes:https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-1/issues/7