### PR TITLE
Student Table Now Appears in the Course Show Page

### DIFF
--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -3,11 +3,12 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import ShowTable from 'main/components/Courses/ShowTable';
+import StudentTable from 'main/components/Student/StudentTable';
 import { useBackend } from 'main/utils/useBackend';
 import { useCurrentUser } from 'main/utils/currentUser';
 
 export default function CoursesShowPage() {
-    let { id } = useParams();
+    let { id, courseId } = useParams();
     const { data: currentUser } = useCurrentUser();
 
     const { data: courses, error: _error, status: _status } =
@@ -23,6 +24,19 @@ export default function CoursesShowPage() {
             []
         );
          // Stryker restore all
+         const { data: students, error: _errors, status: _statuses } =
+         // Stryker disable all 
+         useBackend(
+             [`/api/students/all?courseId=${courseId}`],
+             {
+                 method: "GET", url: "/api/students/all",
+                 params: {
+                     courseId: id
+                 },
+             },
+             []
+         );
+          // Stryker restore all
 
     return (
         <BasicLayout>
@@ -46,6 +60,7 @@ export default function CoursesShowPage() {
                 <p>
                     <strong>Student Roster:</strong>
                     <p>View Students</p>
+                    <StudentTable students={students}/>
                 </p>
             </div>
         </BasicLayout>

--- a/frontend/src/tests/pages/CoursesShowPage.test.js
+++ b/frontend/src/tests/pages/CoursesShowPage.test.js
@@ -27,7 +27,7 @@ jest.mock('react-router-dom', () => {
         __esModule: true,
         ...originalModule,
         useParams: () => ({
-            id: 17
+            id: 17,
         }),
         Navigate: (x) => { mockNavigate(x); return null; }
     };
@@ -145,7 +145,7 @@ describe("CoursesShowPage tests", () => {
         );
 
         await waitFor(() => {
-            expect(axiosMock.history.get.length).toBe(3);
+            expect(axiosMock.history.get.length).toBe(4);
         });
         await waitFor(() => {
             expect(axiosMock.history.get[0].url).toBe("/api/currentUser");
@@ -166,7 +166,7 @@ describe("CoursesShowPage tests", () => {
         );
 
         await waitFor(() => {
-            expect(axiosMock.history.get.length).toBe(3);
+            expect(axiosMock.history.get.length).toBe(4);
         });
         await waitFor(() => {
             expect(axiosMock.history.get[0].method).toBe("get");

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/FrontendProxyController.java
@@ -13,7 +13,7 @@ import java.net.ConnectException;
 @RestController
 public class FrontendProxyController {
   @GetMapping({"/", "/{path:^(?!api|oauth2|swagger-ui).*}/**"})
-  public ResponseEntity<String> proxy(ProxyExchange<String> proxy) {
+  public ResponseEntity<?> proxy(ProxyExchange<byte []> proxy) {
     String path = proxy.path("/");
     try {
       return proxy.uri("http://localhost:3000/" + path).get();


### PR DESCRIPTION
Me and Daniel added a feature where the course show page now displays the student table. We don't have the feature where an admin/instructor can input course roster done yet so to test this, you can go on swagger and add the csv file into the "POST" method for the students section. Then you can click on the show button in courses and it will lead you to the aforementioned tables.

dokku:  http://proj-school-daniel-dev.dokku-09.cs.ucsb.edu

closes:https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-1/issues/13