### PR TITLE
college course drop-down menu for selecting classes, instead of text input

### DIFF
--- a/frontend/src/main/components/Courses/CoursesForm.js
+++ b/frontend/src/main/components/Courses/CoursesForm.js
@@ -2,13 +2,28 @@ import { Button, Form, Row, Col } from 'react-bootstrap';
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 import { enableEndDateValidation } from './dateValidation'; // Import the JavaScript file
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
-function CoursesForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+import axios from 'axios';
+
+
+
+function CoursesForm({ initialContents, submitAction, buttonLabel = "Create"}) { // schooloptions = drop down menu items
+    const [schoolOptions, setSchoolOptions] = useState([]);
     useEffect(() => {
         enableEndDateValidation(); // Call the function to enable end date validation
-    },); // Run only once after component mounts
+        axios.get('/api/schools/all')
+            .then((data) => {
+                return data.data;
+            })
+            .then((jsonData) => {
+                const nameArray = jsonData.map(item => item.name);
+                setSchoolOptions(nameArray);
+            })
+    }, 
     // Stryker disable all
+    []); 
+    // Run only once after component mounts
     const {
         register,
         formState: { errors },
@@ -67,14 +82,26 @@ function CoursesForm({ initialContents, submitAction, buttonLabel = "Create" }) 
             <Row>
                 <Col>
                     <Form.Group className="mb-3" >
-                        <Form.Label htmlFor="school">School</Form.Label>
+                    <Form.Group controlId="school">
+                    <Form.Label>School</Form.Label>
                         <Form.Control
+                            as="select"
                             data-testid="CoursesForm-school"
-                            id="school"
-                            type="text"
                             isInvalid={Boolean(errors.school)}
                             {...register("school", { required: true })}
-                        />
+                        >
+                            <option value="">Select a school</option>
+                            {schoolOptions.map((school, index) => (
+                                <option 
+                                    key={index} 
+                                    value={school}
+                                    selected={school === initialContents?.school ? true : false}
+                                >
+                                    {school}
+                                </option>
+                            ))}
+                        </Form.Control>
+                    </Form.Group>
                         <Form.Control.Feedback type="invalid">
                             {errors.school && 'School is required. '}
                         </Form.Control.Feedback>

--- a/frontend/src/tests/pages/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/CoursesCreatePage.test.js
@@ -8,6 +8,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { schoolsFixtures } from "fixtures/schoolsFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -39,6 +40,8 @@ describe("CourseCreatePage tests", () => {
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/schools/all").reply(200, schoolsFixtures.threeSchools);
+
     });
 
     const queryClient = new QueryClient();
@@ -88,7 +91,7 @@ describe("CourseCreatePage tests", () => {
         const submitButton = screen.getByTestId("CoursesForm-submit");
 
         fireEvent.change(nameField, { target: { value: 'CS156' } });
-        fireEvent.change(schoolField, { target: { value: 'UCSB' } });
+        fireEvent.change(schoolField, { target: { value: 'UC Santa Barbara' } });
         fireEvent.change(termField, { target: { value: 'F23' } });
         fireEvent.change(startDateField, { target: { value: '2023-09-24T12:00:00' } });
         fireEvent.change(endDateField, { target: { value: '2023-12-15T12:00:00' } });
@@ -103,7 +106,7 @@ describe("CourseCreatePage tests", () => {
         expect(axiosMock.history.post[0].params).toEqual(
             {
                 "name": "CS156",
-                "school": "UCSB",
+                "school": "UC Santa Barbara",
                 "term": "F23",
                 "startDate": "2023-09-24T12:00",
                 "endDate": "2023-12-15T12:00",
@@ -116,4 +119,3 @@ describe("CourseCreatePage tests", () => {
 
 
 });
-

--- a/frontend/src/tests/pages/CoursesEditPage.test.js
+++ b/frontend/src/tests/pages/CoursesEditPage.test.js
@@ -6,6 +6,8 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { schoolsFixtures } from "fixtures/schoolsFixtures";
+
 
 import mockConsole from "jest-mock-console";
 
@@ -49,6 +51,8 @@ describe("CoursesEditPage tests", () => {
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
             axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).timeout();
+            axiosMock.onGet("/api/schools/all").reply(200, schoolsFixtures.threeSchools);
+
         });
 
         const queryClient = new QueryClient();
@@ -78,10 +82,11 @@ describe("CoursesEditPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/schools/all").reply(200, schoolsFixtures.threeSchools);
             axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, {
                 id: 17,
                 name: "CS 156",
-                school: "UCSB",
+                school: "UC Santa Barbara",
                 term: "f23",
                 startDate: "2023-09-29T00:00",
                 endDate: "2023-12-15T00:00",
@@ -90,7 +95,7 @@ describe("CoursesEditPage tests", () => {
             axiosMock.onPut('/api/courses/update').reply(200, {
                 id: "17",
                 name: "CS 148",
-                school: "UCSB",
+                school: "UC Santa Barbara",
                 term: "w23",
                 startDate: "2024-01-10T00:00",
                 endDate: "2023-03-12T00:00",
@@ -132,7 +137,7 @@ describe("CoursesEditPage tests", () => {
 
             expect(idField).toHaveValue("17");
             expect(nameField).toHaveValue("CS 156");
-            expect(schoolField).toHaveValue("UCSB");
+            expect(schoolField).toHaveValue("UC Santa Barbara");
             expect(termField).toHaveValue("f23");
             expect(startField).toHaveValue("2023-09-29T00:00");
             expect(endField).toHaveValue("2023-12-15T00:00");
@@ -163,7 +168,7 @@ describe("CoursesEditPage tests", () => {
 
             expect(idField).toHaveValue("17");
             expect(nameField).toHaveValue("CS 156");
-            expect(schoolField).toHaveValue("UCSB");
+            expect(schoolField.value).toBe('UC Santa Barbara');
             expect(termField).toHaveValue("f23");
             expect(startField).toHaveValue("2023-09-29T00:00");
             expect(endField).toHaveValue("2023-12-15T00:00");
@@ -171,7 +176,7 @@ describe("CoursesEditPage tests", () => {
             expect(submitButton).toBeInTheDocument();
 
             fireEvent.change(nameField, { target: { value: "CS 148" } })
-            fireEvent.change(schoolField, { target: { value: "UCSB" } })
+            fireEvent.change(schoolField, { target: { value: "UC San Diego" } })
             fireEvent.change(termField, { target: { value: "w23" } })
             fireEvent.change(startField, { target: { value: "2024-01-10T00:00" } })
             fireEvent.change(endField, { target: { value: "2023-03-12T00:00" } })
@@ -184,11 +189,10 @@ describe("CoursesEditPage tests", () => {
             expect(mockNavigate).toBeCalledWith({ "to": "/courses" });
 
             expect(axiosMock.history.put.length).toBe(1); // times called
-            expect(axiosMock.history.put[0].params).toEqual({ id: 17, name: "CS 148", endDate: "2023-03-12T00:00", startDate: "2024-01-10T00:00", school: "UCSB", term: "w23", githubOrg: "ucsb-cs156-w23" });
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17, name: "CS 148", endDate: "2023-03-12T00:00", startDate: "2024-01-10T00:00", school: "UC San Diego", term: "w23", githubOrg: "ucsb-cs156-w23" });
 
         });
 
        
     });
 });
-


### PR DESCRIPTION
dokku: https://organic-qa.dokku-09.cs.ucsb.edu/
In this PR, I changed the school textbox input field in the course creation page into a dropdown selection instead.
This is what it looks like:
![dropdown pr proj organic](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-1/assets/147559307/cd180bc1-97a8-49a8-a09b-f67655ff4e0b)
Basically, the dropdown selection shown calls api/schools/all to populate the dropdown with schools created on the schools creation page.
To test the feature: make sure a school is created in the school creation page first, then navigate to the courses page and click create course and select the box in the school field to see the dropdown.